### PR TITLE
[TASK] Multisite support

### DIFF
--- a/database/influxdb/node.go
+++ b/database/influxdb/node.go
@@ -31,6 +31,9 @@ func nodeToInflux(node *runtime.Node) (tags models.Tags, fields models.Fields) {
 
 	if nodeinfo := node.Nodeinfo; nodeinfo != nil {
 		tags.SetString("hostname", nodeinfo.Hostname)
+		if len(nodeinfo.System.SiteCode) > 0 {
+			tags.SetString("site_code", nodeinfo.System.SiteCode)
+		}
 		if owner := nodeinfo.Owner; owner != nil {
 			tags.SetString("owner", owner.Contact)
 		}

--- a/database/influxdb/node_test.go
+++ b/database/influxdb/node_test.go
@@ -49,6 +49,9 @@ func TestToInflux(t *testing.T) {
 			Owner: &data.Owner{
 				Contact: "nobody",
 			},
+			System: data.System{
+				SiteCode: "ffhb",
+			},
 			Wireless: &data.Wireless{
 				TxPower24: 3,
 				Channel24: 4,
@@ -70,6 +73,7 @@ func TestToInflux(t *testing.T) {
 
 	assert.Equal("foobar", tags.GetString("nodeid"))
 	assert.Equal("nobody", tags.GetString("owner"))
+	assert.Equal("ffhb", tags.GetString("site_code"))
 	assert.Equal(0.5, fields["load"])
 	assert.Equal(0, fields["neighbours.lldp"])
 	assert.Equal(1, fields["neighbours.batadv"])

--- a/database/influxdb/stats_test.go
+++ b/database/influxdb/stats_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 func TestGlobalStats(t *testing.T) {
-	stats := runtime.NewGlobalStats(createTestNodes())
+	stats := runtime.NewGlobalStats(createTestNodes(), "ffhb01")
 
 	assert := assert.New(t)
 	fields := GlobalStatsFields(stats)
 
 	// check fields
-	assert.EqualValues(3, fields["nodes"])
+	assert.EqualValues(2, fields["nodes"])
 }
 
 func createTestNodes() *runtime.Nodes {
@@ -32,6 +32,9 @@ func createTestNodes() *runtime.Nodes {
 			Hardware: data.Hardware{
 				Model: "TP-Link 841",
 			},
+			System: data.System{
+				SiteCode: "ffhb01",
+			},
 		},
 	}
 	nodeData.NodeInfo.Software.Firmware.Release = "2016.1.6+entenhausen1"
@@ -46,6 +49,9 @@ func createTestNodes() *runtime.Nodes {
 		NodeInfo: &data.NodeInfo{
 			Hardware: data.Hardware{
 				Model: "TP-Link 841",
+			},
+			System: data.System{
+				SiteCode: "ffhb01",
 			},
 		},
 	})

--- a/runtime/stats.go
+++ b/runtime/stats.go
@@ -17,32 +17,33 @@ type GlobalStats struct {
 }
 
 //NewGlobalStats returns global statistics for InfluxDB
-func NewGlobalStats(nodes *Nodes) (result *GlobalStats) {
+func NewGlobalStats(nodes *Nodes, site string) (result *GlobalStats) {
 	result = &GlobalStats{
 		Firmwares: make(CounterMap),
 		Models:    make(CounterMap),
 	}
 
-	nodes.Lock()
 	for _, node := range nodes.List {
 		if node.Online {
-			result.Nodes++
-			if stats := node.Statistics; stats != nil {
-				result.Clients += stats.Clients.Total
-				result.ClientsWifi24 += stats.Clients.Wifi24
-				result.ClientsWifi5 += stats.Clients.Wifi5
-				result.ClientsWifi += stats.Clients.Wifi
-			}
-			if node.Gateway {
-				result.Gateways++
-			}
 			if info := node.Nodeinfo; info != nil {
-				result.Models.Increment(info.Hardware.Model)
-				result.Firmwares.Increment(info.Software.Firmware.Release)
+				if len(site) == 0 || info.System.SiteCode == site {
+					result.Nodes++
+					if stats := node.Statistics; stats != nil {
+						result.Clients += stats.Clients.Total
+						result.ClientsWifi24 += stats.Clients.Wifi24
+						result.ClientsWifi5 += stats.Clients.Wifi5
+						result.ClientsWifi += stats.Clients.Wifi
+					}
+					if node.Gateway {
+						result.Gateways++
+					}
+
+					result.Models.Increment(info.Hardware.Model)
+					result.Firmwares.Increment(info.Software.Firmware.Release)
+				}
 			}
 		}
 	}
-	nodes.Unlock()
 	return
 }
 

--- a/runtime/stats_test.go
+++ b/runtime/stats_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGlobalStats(t *testing.T) {
-	stats := NewGlobalStats(createTestNodes())
+	stats := NewGlobalStats(createTestNodes(), "ffhb")
 
 	assert := assert.New(t)
 	assert.EqualValues(1, stats.Gateways)
@@ -39,6 +39,9 @@ func createTestNodes() *Nodes {
 			Hardware: data.Hardware{
 				Model: "TP-Link 841",
 			},
+			System: data.System{
+				SiteCode: "ffhb",
+			},
 		},
 	}
 	nodeData.NodeInfo.Software.Firmware.Release = "2016.1.6+entenhausen1"
@@ -54,6 +57,9 @@ func createTestNodes() *Nodes {
 			Hardware: data.Hardware{
 				Model: "TP-Link 841",
 			},
+			System: data.System{
+				SiteCode: "ffhb",
+			},
 		},
 	})
 
@@ -62,6 +68,9 @@ func createTestNodes() *Nodes {
 			VPN: true,
 			Hardware: data.Hardware{
 				Model: "Xeon Multi-Core",
+			},
+			System: data.System{
+				SiteCode: "ffhb",
 			},
 		},
 	})


### PR DESCRIPTION
Other communties has multiplie sites and multiple interfaces to listen

Influxdb
- [x] save `node` measurement with `site_code` tag
- [ ] save `global` measurement with `site_code` tag
- [ ] save `firemware` measurement with `site_code` tag
- [ ] save `model` measurement with `site_code` tag

Collector (extra)
- [ ] listen on multiple interfaces
- [ ] send request on multiple interfaces