### PR TITLE
[BUGFIX] omit longitude and latitude in location if empty

### DIFF
--- a/data/nodeinfo.go
+++ b/data/nodeinfo.go
@@ -43,8 +43,8 @@ type System struct {
 
 // Location struct
 type Location struct {
-	Longtitude float64 `json:"longitude"`
-	Latitude   float64 `json:"latitude"`
+	Longtitude float64 `json:"longitude,omitempty"`
+	Latitude   float64 `json:"latitude,omitempty"`
 	Altitude   float64 `json:"altitude,omitempty"`
 }
 


### PR DESCRIPTION
This will omit nil values for longitude and latitude in location.

Without this a nil value will be represented as 0 which is a valid value to meshviewer and the node is displayed at a wrong position.