### PR TITLE
[TASK] add job tag to influxdb database type

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -63,11 +63,12 @@ delete_interval = "1h"
 #  model: store count of nodes tagged with hardware model
 [[database.connection.influxdb]]
 enable   = false
-job      = "ffhb01"
 address  = "http://localhost:8086"
 database = "ffhb"
 username = ""
 password = ""
+# tag the data with an optional job tag
+job      = "ffhb01"
 
 [[database.connection.logging]]
 enable   = false

--- a/config_example.toml
+++ b/config_example.toml
@@ -63,6 +63,7 @@ delete_interval = "1h"
 #  model: store count of nodes tagged with hardware model
 [[database.connection.influxdb]]
 enable   = false
+job      = "ffhb01"
 address  = "http://localhost:8086"
 database = "ffhb"
 username = ""

--- a/config_example.toml
+++ b/config_example.toml
@@ -67,8 +67,11 @@ address  = "http://localhost:8086"
 database = "ffhb"
 username = ""
 password = ""
-# tag the data with an optional job tag
-job      = "ffhb01"
+# tagging of the data are optional
+# be carefull tags by system would overright config
+[database.connection.influxdb.tags]
+site = "ffhb01"
+system = "testing"
 
 [[database.connection.logging]]
 enable   = false

--- a/database/influxdb/database.go
+++ b/database/influxdb/database.go
@@ -46,7 +46,10 @@ func (c Config) Password() string {
 	return c["password"].(string)
 }
 func (c Config) Tags() map[string]interface{} {
-	return c["tags"].(map[string]interface{})
+	if c["tags"] != nil {
+		return c["tags"].(map[string]interface{})
+	}
+	return nil
 }
 
 func init() {

--- a/database/influxdb/database.go
+++ b/database/influxdb/database.go
@@ -1,7 +1,6 @@
 package influxdb
 
 import (
-	"fmt"
 	"log"
 	"sync"
 	"time"
@@ -82,14 +81,11 @@ func Connect(configuration interface{}) (database.Connection, error) {
 	return db, nil
 }
 
-func (conn *Connection) DeleteNode(deleteAfter time.Duration) {
-	query := fmt.Sprintf("delete from %s where time < now() - %ds", MeasurementNode, deleteAfter/time.Second)
-	conn.client.Query(client.NewQuery(query, conn.config.Database(), "m"))
-}
-
-func (conn *Connection) addPoint(name string, tags models.Tags, fields models.Fields, time time.Time) {
-	tags.SetString("job", db.config.Job())
-	point, err := client.NewPoint(name, tags.Map(), fields, time)
+func (conn *Connection) addPoint(name string, tags models.Tags, fields models.Fields, t ...time.Time) {
+	if job := conn.config.Job(); job != "" {
+		tags.SetString("job", job)
+	}
+	point, err := client.NewPoint(name, tags.Map(), fields, t...)
 	if err != nil {
 		panic(err)
 	}

--- a/database/influxdb/database_test.go
+++ b/database/influxdb/database_test.go
@@ -1,0 +1,53 @@
+package influxdb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/influxdb/models"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddPoint(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test add Point with tags
+	connection := &Connection{
+		config: map[string]interface{}{
+			"tags": map[string]interface{}{
+				"testtag": "value",
+			},
+		},
+		points: make(chan *client.Point, 1),
+	}
+
+	connection.addPoint("name", models.Tags{}, models.Fields{"clients.total": 10}, time.Now())
+	point := <-connection.points
+	assert.NotNil(point)
+	tags := point.Tags()
+	assert.NotNil(tags)
+	assert.Equal(tags["testtag"], "value")
+	assert.NotEqual(tags["testtag2"], "value")
+
+	// Tried to overright by config
+	connection.config["tags"] = map[string]interface{}{
+		"nodeid": "value",
+	}
+
+	tagsOrigin := models.Tags{}
+	tagsOrigin.SetString("nodeid", "collected")
+
+	connection.addPoint("name", tagsOrigin, models.Fields{"clients.total": 10}, time.Now())
+	point = <-connection.points
+	assert.NotNil(point)
+	tags = point.Tags()
+	assert.NotNil(tags)
+	assert.Equal(tags["nodeid"], "collected")
+
+	// Test panic if it was not possible to create a point
+	assert.Panics(func() {
+		connection.addPoint("name", models.Tags{}, nil, time.Now())
+	})
+}

--- a/database/influxdb/database_test.go
+++ b/database/influxdb/database_test.go
@@ -13,13 +13,9 @@ import (
 func TestAddPoint(t *testing.T) {
 	assert := assert.New(t)
 
-	// Test add Point with tags
+	// Test add Point without tags
 	connection := &Connection{
-		config: map[string]interface{}{
-			"tags": map[string]interface{}{
-				"testtag": "value",
-			},
-		},
+		config: map[string]interface{}{},
 		points: make(chan *client.Point, 1),
 	}
 
@@ -27,6 +23,18 @@ func TestAddPoint(t *testing.T) {
 	point := <-connection.points
 	assert.NotNil(point)
 	tags := point.Tags()
+	assert.NotNil(tags)
+	assert.NotEqual(tags["testtag2"], "value")
+
+	// Test add Point with tags
+	connection.config["tags"] = map[string]interface{}{
+		"testtag": "value",
+	}
+
+	connection.addPoint("name", models.Tags{}, models.Fields{"clients.total": 10}, time.Now())
+	point = <-connection.points
+	assert.NotNil(point)
+	tags = point.Tags()
 	assert.NotNil(tags)
 	assert.Equal(tags["testtag"], "value")
 	assert.NotEqual(tags["testtag2"], "value")


### PR DESCRIPTION
This patch adds the posibility, to add an additional tag (called `job`) to influx data. This may be helpful if you are running multiple sites .