### PR TITLE
Fix airtime calculation

### DIFF
--- a/data/airtime_test.go
+++ b/data/airtime_test.go
@@ -19,62 +19,59 @@ func TestUtilization(t *testing.T) {
 
 	t1 := &WirelessAirtime{
 		ActiveTime: 20,
-		BusyTime:   0,
+		BusyTime:   5,
 		TxTime:     5,
 		RxTime:     0,
 	}
 	t2 := &WirelessAirtime{
 		ActiveTime: 120,
-		BusyTime:   10,
+		BusyTime:   50,
 		TxTime:     25,
 		RxTime:     15,
 	}
-	t3 := &WirelessAirtime{
-		ActiveTime: 200,
-		BusyTime:   40,
-		TxTime:     35,
-		RxTime:     15,
-	}
 
-	t1.SetUtilization(t2)
-	assert.Zero(t1.ChanUtil)
-	assert.Zero(t1.TxUtil)
-	assert.Zero(t1.RxUtil)
+	t1.setUtilization(t1)
+	assert.NotZero(t1.ChanUtil)
+	assert.EqualValues(0, t2.ChanUtil)
+	assert.EqualValues(0, t2.RxUtil)
+	assert.EqualValues(0, t2.TxUtil)
 
-	t2.SetUtilization(t1)
+	t2.setUtilization(t1)
 	assert.NotZero(t2.ChanUtil)
 	assert.EqualValues(45, t2.ChanUtil)
-	assert.EqualValues(20, t2.RxUtil)
-	assert.EqualValues(15, t2.TxUtil)
-
-	t3.SetUtilization(t2)
-	assert.EqualValues(50, t3.ChanUtil)
-	assert.EqualValues(12.5, t3.RxUtil)
-	assert.EqualValues(0, t3.TxUtil)
+	assert.EqualValues(15, t2.RxUtil)
+	assert.EqualValues(20, t2.TxUtil)
 }
 
 func TestWirelessStatistics(t *testing.T) {
 	assert := assert.New(t)
 
+	// This is the current value
 	stats := WirelessStatistics([]*WirelessAirtime{{
-		Frequency:   2400,
-		ActiveTime: 20,
-		TxTime:     10,
-	}})
-
-	// Different Frequency, should not change anything
-	stats.SetUtilization([]*WirelessAirtime{{
-		Frequency:   5000,
-		ActiveTime: 15,
-		TxTime:     1,
-	}})
-	assert.EqualValues(0, stats[0].ChanUtil)
-
-	// Same Frequency, should set the utilization
-	stats.SetUtilization([]*WirelessAirtime{{
-		Frequency:   2400,
+		Frequency:  2400,
 		ActiveTime: 10,
-		TxTime:     5,
+		BusyTime:   4,
+		RxTime:     3,
 	}})
-	assert.EqualValues(50, stats[0].ChanUtil)
+
+	// previous value: Different Frequency, should not change anything
+	stats.SetUtilization([]*WirelessAirtime{{
+		Frequency:  5000,
+		ActiveTime: 5,
+		RxTime:     1,
+	}})
+	assert.Zero(0, stats[0].ChanUtil)
+	assert.Zero(0, stats[0].RxUtil)
+	assert.Zero(0, stats[0].TxUtil)
+
+	// previous value: Same Frequency, should set the utilization
+	stats.SetUtilization([]*WirelessAirtime{{
+		Frequency:  2400,
+		ActiveTime: 5,
+		RxTime:     2,
+		BusyTime:   1,
+	}})
+	assert.EqualValues(60, stats[0].ChanUtil)
+	assert.EqualValues(20, stats[0].RxUtil)
+	assert.EqualValues(0, stats[0].TxUtil)
 }


### PR DESCRIPTION
`busy` includes `rx` and `tx`