### PR TITLE
[RFC] influxdb: replace log.Fatal() by log.Print()

### DIFF
--- a/database/influxdb/database.go
+++ b/database/influxdb/database.go
@@ -149,7 +149,7 @@ func (conn *Connection) addWorker() {
 			log.Println("saving", len(bp.Points()), "points")
 
 			if err = conn.client.Write(bp); err != nil {
-				log.Fatal(err)
+				log.Print(err)
 			}
 			writeNow = false
 			bp = nil


### PR DESCRIPTION
Fatal() calls os.Exit(1), which causes yanic.service to fail if database is not reachable.