### PR TITLE
[TASK] add socket database type

### DIFF
--- a/.test-coverage
+++ b/.test-coverage
@@ -15,7 +15,7 @@ FAIL=0
 for dir in $(find . -maxdepth 10 -not -path './.git*' -not -path '*/_*' -type d);
 do
   if ls $dir/*.go &> /dev/null; then
-    go test -p 1 -v -covermode=count -coverprofile=profile.tmp $dir || FAIL=$?
+    go test -v -covermode=count -coverprofile=profile.tmp $dir || FAIL=$?
     if [ -f profile.tmp ]
     then
       tail -n +2 < profile.tmp >> profile.cov

--- a/.test-coverage
+++ b/.test-coverage
@@ -15,7 +15,7 @@ FAIL=0
 for dir in $(find . -maxdepth 10 -not -path './.git*' -not -path '*/_*' -type d);
 do
   if ls $dir/*.go &> /dev/null; then
-    go test -v -covermode=count -coverprofile=profile.tmp $dir || FAIL=$?
+    go test -p 1 -v -covermode=count -coverprofile=profile.tmp $dir || FAIL=$?
     if [ -f profile.tmp ]
     then
       tail -n +2 < profile.tmp >> profile.cov

--- a/config_example.toml
+++ b/config_example.toml
@@ -163,7 +163,16 @@ address  = "localhost:2003"
 # probably wont care much about "polluting" the namespace.
 prefix   = "freifunk"
 
-# Logging
 [[database.connection.logging]]
 enable   = false
 path     = "/var/log/yanic.log"
+
+[[database.connection.socket]]
+enable   = false
+type     = "tcp"
+address  = ":8081"
+
+[[database.connection.socket]]
+enable   = false
+type     = "unix"
+address  = "/var/lib/collector/database.socket"

--- a/database/all/main.go
+++ b/database/all/main.go
@@ -4,4 +4,5 @@ import (
 	_ "github.com/FreifunkBremen/yanic/database/graphite"
 	_ "github.com/FreifunkBremen/yanic/database/influxdb"
 	_ "github.com/FreifunkBremen/yanic/database/logging"
+	_ "github.com/FreifunkBremen/yanic/database/socket"
 )

--- a/database/socket/client/dial.go
+++ b/database/socket/client/dial.go
@@ -1,0 +1,86 @@
+package yanic
+
+import (
+	"encoding/json"
+	"log"
+	"net"
+
+	"github.com/FreifunkBremen/yanic/database/socket"
+	"github.com/FreifunkBremen/yanic/runtime"
+)
+
+type Dialer struct {
+	conn              net.Conn
+	queue             chan socket.Message
+	quit              chan struct{}
+	NodeHandler       func(*runtime.Node)
+	GlobalsHandler    func(*runtime.GlobalStats)
+	PruneNodesHandler func()
+}
+
+func Dial(ctype, addr string) *Dialer {
+	conn, err := net.Dial(ctype, addr)
+	if err != nil {
+		log.Panicf("yanic dial to %s:%s failed", ctype, addr)
+	}
+	dialer := &Dialer{
+		conn:  conn,
+		queue: make(chan socket.Message),
+		quit:  make(chan struct{}),
+	}
+
+	return dialer
+}
+
+func (d *Dialer) Start() {
+	go d.reciever()
+	d.parser()
+}
+func (d *Dialer) Close() {
+	d.conn.Close()
+	close(d.quit)
+}
+
+func (d *Dialer) reciever() {
+	decoder := json.NewDecoder(d.conn)
+	var msg socket.Message
+
+	for {
+		select {
+		case <-d.quit:
+			close(d.queue)
+			return
+		default:
+			decoder.Decode(&msg)
+			d.queue <- msg
+		}
+	}
+}
+
+func (d *Dialer) parser() {
+	for msg := range d.queue {
+		switch msg.Event {
+		case socket.MessageEventInsertNode:
+			if d.NodeHandler != nil {
+				var node runtime.Node
+
+				obj, _ := json.Marshal(msg.Body)
+				json.Unmarshal(obj, &node)
+				d.NodeHandler(&node)
+			}
+		case socket.MessageEventInsertGlobals:
+			if d.GlobalsHandler != nil {
+				var globals runtime.GlobalStats
+
+				obj, _ := json.Marshal(msg.Body)
+				json.Unmarshal(obj, &globals)
+
+				d.GlobalsHandler(&globals)
+			}
+		case socket.MessageEventPruneNodes:
+			if d.PruneNodesHandler != nil {
+				d.PruneNodesHandler()
+			}
+		}
+	}
+}

--- a/database/socket/client/dial.go
+++ b/database/socket/client/dial.go
@@ -2,6 +2,7 @@ package yanic
 
 import (
 	"encoding/json"
+	"io"
 	"log"
 	"net"
 
@@ -56,7 +57,14 @@ func (d *Dialer) receiver() {
 		default:
 			err := decoder.Decode(&msg)
 			if err != nil {
-				log.Printf("[yanic-client] could not decode message %s", err)
+				if err == io.EOF {
+					log.Printf("[yanic-client] connection closed: %s", err)
+					d.conn.Close()
+					close(d.quit)
+					close(d.queue)
+					return
+				}
+				log.Printf("[yanic-client] could not decode message: %s", err)
 				continue
 			}
 			select {

--- a/database/socket/client/dial.go
+++ b/database/socket/client/dial.go
@@ -16,6 +16,7 @@ type Dialer struct {
 	queue             chan socket.Message
 	quit              chan struct{}
 	NodeHandler       func(*runtime.Node)
+	LinkHandler       func(*runtime.Link)
 	GlobalsHandler    func(*runtime.GlobalStats)
 	PruneNodesHandler func()
 }
@@ -78,6 +79,15 @@ func (d *Dialer) parser() {
 				obj, _ := json.Marshal(msg.Body)
 				json.Unmarshal(obj, &node)
 				d.NodeHandler(&node)
+			}
+		case socket.MessageEventInsertLink:
+			if d.GlobalsHandler != nil {
+				var link runtime.Link
+
+				obj, _ := json.Marshal(msg.Body)
+				json.Unmarshal(obj, &link)
+
+				d.LinkHandler(&link)
 			}
 		case socket.MessageEventInsertGlobals:
 			if d.GlobalsHandler != nil {

--- a/database/socket/client/dial.go
+++ b/database/socket/client/dial.go
@@ -33,7 +33,7 @@ func Dial(ctype, addr string) *Dialer {
 }
 
 func (d *Dialer) Start() {
-	go d.reciever()
+	go d.receiver()
 	d.parser()
 }
 func (d *Dialer) Close() {
@@ -41,7 +41,7 @@ func (d *Dialer) Close() {
 	close(d.quit)
 }
 
-func (d *Dialer) reciever() {
+func (d *Dialer) receiver() {
 	decoder := json.NewDecoder(d.conn)
 	var msg socket.Message
 

--- a/database/socket/client/dial.go
+++ b/database/socket/client/dial.go
@@ -18,7 +18,7 @@ type Dialer struct {
 	quit              chan struct{}
 	NodeHandler       func(*runtime.Node)
 	LinkHandler       func(*runtime.Link)
-	GlobalsHandler    func(*runtime.GlobalStats)
+	GlobalsHandler    func(*runtime.GlobalStats, string)
 	PruneNodesHandler func()
 }
 
@@ -104,7 +104,7 @@ func (d *Dialer) parser() {
 				obj, _ := json.Marshal(msg.Body)
 				json.Unmarshal(obj, &globals)
 
-				d.GlobalsHandler(&globals)
+				d.GlobalsHandler(&globals, msg.Site)
 			}
 		case socket.MessageEventPruneNodes:
 			if d.PruneNodesHandler != nil {

--- a/database/socket/client/dial_test.go
+++ b/database/socket/client/dial_test.go
@@ -12,7 +12,7 @@ import (
 func TestConnectError(t *testing.T) {
 	assert := assert.New(t)
 	assert.Panics(func() {
-		Dial("tcp6", "[::]:30303")
+		Dial("tcp4", "127.0.0.1:30303")
 	}, "could connect")
 }
 
@@ -20,12 +20,12 @@ func TestRecieveMessages(t *testing.T) {
 	assert := assert.New(t)
 	server, err := socket.Connect(map[string]interface{}{
 		"enable":  true,
-		"type":    "tcp6",
-		"address": "[::]:1337",
+		"type":    "tcp4",
+		"address": "127.0.0.1:10337",
 	})
 	assert.NoError(err)
 
-	d := Dial("tcp6", "[::]:1337")
+	d := Dial("tcp4", "127.0.0.1:10337")
 	assert.NotNil(d)
 	go d.Start()
 	time.Sleep(5 * time.Millisecond)

--- a/database/socket/client/dial_test.go
+++ b/database/socket/client/dial_test.go
@@ -1,0 +1,69 @@
+package yanic
+
+import (
+	"testing"
+	"time"
+
+	"github.com/FreifunkBremen/yanic/database/socket"
+	"github.com/FreifunkBremen/yanic/runtime"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConnectError(t *testing.T) {
+	assert := assert.New(t)
+	assert.Panics(func() {
+		Dial("unix", "/tmp/yanic-database-error.socket")
+	}, "could connect")
+}
+
+func TestRecieveMessages(t *testing.T) {
+	assert := assert.New(t)
+	server, err := socket.Connect(map[string]interface{}{
+		"enable":  true,
+		"type":    "unix",
+		"address": "/tmp/yanic-database.socket",
+	})
+	assert.NoError(err)
+
+	d := Dial("unix", "/tmp/yanic-database.socket")
+	assert.NotNil(d)
+	go d.Start()
+	time.Sleep(5 * time.Millisecond)
+
+	runned := false
+	d.NodeHandler = func(node *runtime.Node) {
+		runned = true
+	}
+	server.InsertNode(nil)
+	time.Sleep(5 * time.Millisecond)
+	assert.True(runned, "node not inserted")
+
+	runned = false
+	d.GlobalsHandler = func(stats *runtime.GlobalStats) {
+		runned = true
+	}
+	server.InsertGlobals(nil, time.Now())
+	time.Sleep(5 * time.Millisecond)
+	assert.True(runned, "global stats not inserted")
+
+	runned = false
+	d.PruneNodesHandler = func() {
+		runned = true
+	}
+	server.PruneNodes(time.Hour * 24 * 7)
+	time.Sleep(5 * time.Millisecond)
+	assert.True(runned, "node not pruned")
+
+	d.Close()
+
+	time.Sleep(5 * time.Millisecond)
+	runned = false
+	d.PruneNodesHandler = func() {
+		runned = true
+	}
+	server.PruneNodes(time.Hour * 24 * 7)
+	time.Sleep(5 * time.Millisecond)
+	assert.False(runned, "message recieve")
+
+	server.Close()
+}

--- a/database/socket/client/dial_test.go
+++ b/database/socket/client/dial_test.go
@@ -53,7 +53,7 @@ func TestReceiveMessages(t *testing.T) {
 	d.LinkHandler = func(link *runtime.Link) {
 		executed.Set(true)
 	}
-	d.GlobalsHandler = func(stats *runtime.GlobalStats) {
+	d.GlobalsHandler = func(stats *runtime.GlobalStats, site string) {
 		executed.Set(true)
 	}
 	d.PruneNodesHandler = func() {
@@ -73,7 +73,7 @@ func TestReceiveMessages(t *testing.T) {
 	assert.True(executed.Get(), "link not inserted")
 
 	executed.Set(false)
-	server.InsertGlobals(nil, time.Now())
+	server.InsertGlobals(nil, time.Now(), "global")
 	time.Sleep(5 * time.Millisecond)
 	assert.True(executed.Get(), "global stats not inserted")
 

--- a/database/socket/client/dial_test.go
+++ b/database/socket/client/dial_test.go
@@ -37,7 +37,6 @@ func (s *SafeBoolean) Get() bool {
 func TestReceiveMessages(t *testing.T) {
 	assert := assert.New(t)
 	server, err := socket.Connect(map[string]interface{}{
-		"enable":  true,
 		"type":    "tcp4",
 		"address": "127.0.0.1:10339",
 	})

--- a/database/socket/client/dial_test.go
+++ b/database/socket/client/dial_test.go
@@ -16,7 +16,7 @@ func TestConnectError(t *testing.T) {
 	}, "could connect")
 }
 
-func TestRecieveMessages(t *testing.T) {
+func TestReceiveMessages(t *testing.T) {
 	assert := assert.New(t)
 	server, err := socket.Connect(map[string]interface{}{
 		"enable":  true,
@@ -30,40 +30,40 @@ func TestRecieveMessages(t *testing.T) {
 	go d.Start()
 	time.Sleep(5 * time.Millisecond)
 
-	runned := false
+	executed := false
 	d.NodeHandler = func(node *runtime.Node) {
-		runned = true
+		executed = true
 	}
 	server.InsertNode(nil)
 	time.Sleep(5 * time.Millisecond)
-	assert.True(runned, "node not inserted")
+	assert.True(executed, "node not inserted")
 
-	runned = false
+	executed = false
 	d.GlobalsHandler = func(stats *runtime.GlobalStats) {
-		runned = true
+		executed = true
 	}
 	server.InsertGlobals(nil, time.Now())
 	time.Sleep(5 * time.Millisecond)
-	assert.True(runned, "global stats not inserted")
+	assert.True(executed, "global stats not inserted")
 
-	runned = false
+	executed = false
 	d.PruneNodesHandler = func() {
-		runned = true
+		executed = true
 	}
 	server.PruneNodes(time.Hour * 24 * 7)
 	time.Sleep(5 * time.Millisecond)
-	assert.True(runned, "node not pruned")
+	assert.True(executed, "node not pruned")
 
 	d.Close()
 
 	time.Sleep(5 * time.Millisecond)
-	runned = false
+	executed = false
 	d.PruneNodesHandler = func() {
-		runned = true
+		executed = true
 	}
 	server.PruneNodes(time.Hour * 24 * 7)
 	time.Sleep(5 * time.Millisecond)
-	assert.False(runned, "message recieve")
+	assert.False(executed, "message re")
 
 	server.Close()
 }

--- a/database/socket/client/dial_test.go
+++ b/database/socket/client/dial_test.go
@@ -12,7 +12,7 @@ import (
 func TestConnectError(t *testing.T) {
 	assert := assert.New(t)
 	assert.Panics(func() {
-		Dial("unix", "/tmp/yanic-database-error.socket")
+		Dial("tcp6", "[::]:30303")
 	}, "could connect")
 }
 
@@ -20,12 +20,12 @@ func TestRecieveMessages(t *testing.T) {
 	assert := assert.New(t)
 	server, err := socket.Connect(map[string]interface{}{
 		"enable":  true,
-		"type":    "unix",
-		"address": "/tmp/yanic-database.socket",
+		"type":    "tcp6",
+		"address": "[::]:1337",
 	})
 	assert.NoError(err)
 
-	d := Dial("unix", "/tmp/yanic-database.socket")
+	d := Dial("tcp6", "[::]:1337")
 	assert.NotNil(d)
 	go d.Start()
 	time.Sleep(5 * time.Millisecond)

--- a/database/socket/client/dial_test.go
+++ b/database/socket/client/dial_test.go
@@ -21,11 +21,14 @@ func TestReceiveMessages(t *testing.T) {
 	server, err := socket.Connect(map[string]interface{}{
 		"enable":  true,
 		"type":    "tcp4",
-		"address": "127.0.0.1:10337",
+		"address": "127.0.0.1:10339",
 	})
 	assert.NoError(err)
 
-	d := Dial("tcp4", "127.0.0.1:10337")
+	// test for drop queue
+	queueMaxSize = 1
+
+	d := Dial("tcp4", "127.0.0.1:10339")
 	assert.NotNil(d)
 	go d.Start()
 	time.Sleep(5 * time.Millisecond)
@@ -54,14 +57,17 @@ func TestReceiveMessages(t *testing.T) {
 	time.Sleep(5 * time.Millisecond)
 	assert.True(executed, "node not pruned")
 
+	// test for drop queue (only visible at test coverage)
+	server.InsertNode(&runtime.Node{})
+	server.InsertNode(&runtime.Node{})
+	server.InsertNode(&runtime.Node{})
+	time.Sleep(5 * time.Millisecond)
+
 	d.Close()
 
 	time.Sleep(5 * time.Millisecond)
 	executed = false
-	d.PruneNodesHandler = func() {
-		executed = true
-	}
-	server.PruneNodes(time.Hour * 24 * 7)
+	server.InsertNode(&runtime.Node{})
 	time.Sleep(5 * time.Millisecond)
 	assert.False(executed, "message re")
 

--- a/database/socket/database.go
+++ b/database/socket/database.go
@@ -33,10 +33,6 @@ func init() {
 func Connect(configuration interface{}) (database.Connection, error) {
 	config := configuration.(map[string]interface{})
 
-	if !config["enable"].(bool) {
-		return nil, nil
-	}
-
 	ln, err := net.Listen(config["type"].(string), config["address"].(string))
 	if err != nil {
 		return nil, err

--- a/database/socket/database.go
+++ b/database/socket/database.go
@@ -8,6 +8,7 @@ package socket
 import (
 	"log"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/FreifunkBremen/yanic/database"
@@ -16,8 +17,9 @@ import (
 
 type Connection struct {
 	database.Connection
-	listener net.Listener
-	clients  map[net.Addr]net.Conn
+	listener  net.Listener
+	clients   map[net.Addr]net.Conn
+	clientMux sync.Mutex
 }
 
 func init() {
@@ -56,8 +58,10 @@ func (conn *Connection) PruneNodes(deleteAfter time.Duration) {
 }
 
 func (conn *Connection) Close() {
+	conn.clientMux.Lock()
 	for _, c := range conn.clients {
 		c.Close()
 	}
+	conn.clientMux.Unlock()
 	conn.listener.Close()
 }

--- a/database/socket/database.go
+++ b/database/socket/database.go
@@ -1,10 +1,11 @@
 package socket
 
-/**
- * This database type is just for,
- * - debugging without a influxconn
- * - example for other developers for new databases
+/*
+ * This socket database is to run another service
+ * (without flooding the network with respondd packages)
+ * e.g. https://github.com/FreifunkBremen/freifunkmanager
  */
+
 import (
 	"log"
 	"net"
@@ -46,15 +47,15 @@ func Connect(configuration interface{}) (database.Connection, error) {
 }
 
 func (conn *Connection) InsertNode(node *runtime.Node) {
-	conn.sendJSON(EventMessage{Event: "insert_node", Body: node})
+	conn.sendJSON(Message{Event: MessageEventInsertNode, Body: node})
 }
 
 func (conn *Connection) InsertGlobals(stats *runtime.GlobalStats, time time.Time) {
-	conn.sendJSON(EventMessage{Event: "insert_globals", Body: stats})
+	conn.sendJSON(Message{Event: MessageEventInsertGlobals, Body: stats})
 }
 
 func (conn *Connection) PruneNodes(deleteAfter time.Duration) {
-	conn.sendJSON(EventMessage{Event: "prune_nodes"})
+	conn.sendJSON(Message{Event: MessageEventPruneNodes})
 }
 
 func (conn *Connection) Close() {

--- a/database/socket/database.go
+++ b/database/socket/database.go
@@ -1,0 +1,82 @@
+package socket
+
+/**
+ * This database type is just for,
+ * - debugging without a influxconn
+ * - example for other developers for new databases
+ */
+import (
+	"log"
+	"net"
+	"time"
+
+	"github.com/FreifunkBremen/yanic/database"
+	"github.com/FreifunkBremen/yanic/runtime"
+)
+
+type Connection struct {
+	database.Connection
+	config   Config
+	listener net.Listener
+	clients  map[net.Addr]net.Conn
+}
+
+type Config map[string]interface{}
+
+func (c Config) Enable() bool {
+	return c["enable"].(bool)
+}
+func (c Config) Type() string {
+	return c["type"].(string)
+}
+func (c Config) Address() string {
+	return c["address"].(string)
+}
+
+func init() {
+	database.RegisterAdapter("socket", Connect)
+}
+
+func Connect(configuration interface{}) (database.Connection, error) {
+	var config Config
+	config = configuration.(map[string]interface{})
+	if !config.Enable() {
+		return nil, nil
+	}
+
+	ln, err := net.Listen(config.Type(), config.Address())
+	if err != nil {
+		return nil, err
+	}
+	conn := &Connection{config: config, listener: ln, clients: make(map[net.Addr]net.Conn)}
+	go conn.handleSocketConnection(ln)
+
+	log.Println("[socket-database] listen on: ", ln.Addr())
+
+	return conn, nil
+}
+
+func (conn *Connection) InsertNode(node *runtime.Node) {
+	conn.sendJSON(EventMessage{Event: "insert_node", Body: node})
+}
+
+func (conn *Connection) InsertGlobals(stats *runtime.GlobalStats, time time.Time) {
+	conn.sendJSON(EventMessage{Event: "insert_globals", Body: stats})
+}
+
+func (conn *Connection) PruneNodes(deleteAfter time.Duration) {
+	conn.sendJSON(EventMessage{Event: "prune_nodes"})
+}
+
+func (conn *Connection) Close() {
+	for _, c := range conn.clients {
+		err := c.Close()
+		if err != nil {
+			log.Println("[socket-database] client was not able to close:", err)
+		}
+	}
+	err := conn.listener.Close()
+	if err != nil {
+		log.Println("[socket-database] server was not able to close:", err)
+	}
+}

--- a/database/socket/database.go
+++ b/database/socket/database.go
@@ -16,21 +16,8 @@ import (
 
 type Connection struct {
 	database.Connection
-	config   Config
 	listener net.Listener
 	clients  map[net.Addr]net.Conn
-}
-
-type Config map[string]interface{}
-
-func (c Config) Enable() bool {
-	return c["enable"].(bool)
-}
-func (c Config) Type() string {
-	return c["type"].(string)
-}
-func (c Config) Address() string {
-	return c["address"].(string)
 }
 
 func init() {
@@ -38,17 +25,17 @@ func init() {
 }
 
 func Connect(configuration interface{}) (database.Connection, error) {
-	var config Config
-	config = configuration.(map[string]interface{})
-	if !config.Enable() {
+	config := configuration.(map[string]interface{})
+
+	if !config["enable"].(bool) {
 		return nil, nil
 	}
 
-	ln, err := net.Listen(config.Type(), config.Address())
+	ln, err := net.Listen(config["type"].(string), config["address"].(string))
 	if err != nil {
 		return nil, err
 	}
-	conn := &Connection{config: config, listener: ln, clients: make(map[net.Addr]net.Conn)}
+	conn := &Connection{listener: ln, clients: make(map[net.Addr]net.Conn)}
 	go conn.handleSocketConnection(ln)
 
 	log.Println("[socket-database] listen on: ", ln.Addr())

--- a/database/socket/database.go
+++ b/database/socket/database.go
@@ -30,9 +30,7 @@ func init() {
 	database.RegisterAdapter("socket", Connect)
 }
 
-func Connect(configuration interface{}) (database.Connection, error) {
-	config := configuration.(map[string]interface{})
-
+func Connect(config map[string]interface{}) (database.Connection, error) {
 	ln, err := net.Listen(config["type"].(string), config["address"].(string))
 	if err != nil {
 		return nil, err
@@ -58,8 +56,8 @@ func (conn *Connection) InsertLink(link *runtime.Link, time time.Time) {
 	conn.sendJSON(&Message{Event: MessageEventInsertLink, Body: link})
 }
 
-func (conn *Connection) InsertGlobals(stats *runtime.GlobalStats, time time.Time) {
-	conn.sendJSON(&Message{Event: MessageEventInsertGlobals, Body: stats})
+func (conn *Connection) InsertGlobals(stats *runtime.GlobalStats, time time.Time, site string) {
+	conn.sendJSON(&Message{Event: MessageEventInsertGlobals, Body: stats, Site: site})
 }
 
 func (conn *Connection) PruneNodes(deleteAfter time.Duration) {

--- a/database/socket/database.go
+++ b/database/socket/database.go
@@ -58,6 +58,10 @@ func (conn *Connection) InsertNode(node *runtime.Node) {
 	conn.sendJSON(&Message{Event: MessageEventInsertNode, Body: node})
 }
 
+func (conn *Connection) InsertLink(link *runtime.Link, time time.Time) {
+	conn.sendJSON(&Message{Event: MessageEventInsertLink, Body: link})
+}
+
 func (conn *Connection) InsertGlobals(stats *runtime.GlobalStats, time time.Time) {
 	conn.sendJSON(&Message{Event: MessageEventInsertGlobals, Body: stats})
 }

--- a/database/socket/database.go
+++ b/database/socket/database.go
@@ -16,12 +16,14 @@ import (
 	"github.com/FreifunkBremen/yanic/runtime"
 )
 
+var queueMaxSize = 1024
+
 type Connection struct {
 	database.Connection
 	listener  net.Listener
 	clients   map[net.Addr]net.Conn
 	clientMux sync.Mutex
-	buffer    chan *Message
+	queue     chan *Message
 }
 
 func init() {
@@ -42,7 +44,7 @@ func Connect(configuration interface{}) (database.Connection, error) {
 	conn := &Connection{
 		listener: ln,
 		clients:  make(map[net.Addr]net.Conn),
-		buffer:   make(chan *Message),
+		queue:    make(chan *Message, queueMaxSize),
 	}
 	go conn.handleSocketConnection(ln)
 	go conn.writer()

--- a/database/socket/database.go
+++ b/database/socket/database.go
@@ -70,13 +70,7 @@ func (conn *Connection) PruneNodes(deleteAfter time.Duration) {
 
 func (conn *Connection) Close() {
 	for _, c := range conn.clients {
-		err := c.Close()
-		if err != nil {
-			log.Println("[socket-database] client was not able to close:", err)
-		}
+		c.Close()
 	}
-	err := conn.listener.Close()
-	if err != nil {
-		log.Println("[socket-database] server was not able to close:", err)
-	}
+	conn.listener.Close()
 }

--- a/database/socket/database.go
+++ b/database/socket/database.go
@@ -24,6 +24,7 @@ type Connection struct {
 	clients   map[net.Addr]net.Conn
 	clientMux sync.Mutex
 	queue     chan *Message
+	running   sync.WaitGroup
 }
 
 func init() {
@@ -71,4 +72,5 @@ func (conn *Connection) Close() {
 	}
 	conn.clientMux.Unlock()
 	conn.listener.Close()
+	conn.running.Wait()
 }

--- a/database/socket/database_test.go
+++ b/database/socket/database_test.go
@@ -42,25 +42,31 @@ func TestClient(t *testing.T) {
 
 	config["enable"] = true
 	config["type"] = "unix"
-	config["address"] = "/tmp/yanic-database.socket"
+	config["address"] = "/tmp/yanic-database2.socket"
 
 	conn, err := Connect(config)
 	assert.NoError(err, "connection should work")
 	assert.NotNil(conn)
 
-	client, err := net.Dial("unix", "/tmp/yanic-database.socket")
+	client, err := net.Dial("unix", "/tmp/yanic-database2.socket")
 	assert.NoError(err, "connection should work")
 	assert.NotNil(client)
-	time.Sleep(1)
+	time.Sleep(time.Duration(3) * time.Microsecond)
 
 	conn.InsertNode(&runtime.Node{})
 	conn.InsertGlobals(&runtime.GlobalStats{}, time.Now())
-	conn.PruneNodes(time.Duration(3))
+	time.Sleep(time.Duration(3) * time.Microsecond)
 
+	// to reach in sendJSON removing of disconnection
 	err = client.Close()
 	assert.NoError(err, "disconnect should work")
-	time.Sleep(1)
+	time.Sleep(time.Duration(3) * time.Microsecond)
 	conn.InsertNode(&runtime.Node{})
+	time.Sleep(time.Duration(3) * time.Microsecond)
+
+	// to reach all parts of conn.Close()
+	client, err = net.Dial("unix", "/tmp/yanic-database2.socket")
+	time.Sleep(time.Duration(3) * time.Microsecond)
 
 	conn.Close()
 }

--- a/database/socket/database_test.go
+++ b/database/socket/database_test.go
@@ -44,13 +44,16 @@ func TestClient(t *testing.T) {
 
 	config["enable"] = true
 	config["type"] = "tcp4"
-	config["address"] = "127.0.0.1:10337"
+	config["address"] = "127.0.0.1:10338"
+
+	// test for drop queue
+	queueMaxSize = 1
 
 	conn, err := Connect(config)
 	assert.NoError(err, "connection should work")
 	assert.NotNil(conn)
 
-	client, err := net.Dial("tcp4", "127.0.0.1:10337")
+	client, err := net.Dial("tcp4", "127.0.0.1:10338")
 	assert.NoError(err, "connection should work")
 	assert.NotNil(client)
 	time.Sleep(time.Duration(3) * time.Microsecond)
@@ -69,7 +72,12 @@ func TestClient(t *testing.T) {
 	conn.PruneNodes(time.Hour * 24 * 7)
 	decoder.Decode(&msg)
 	assert.Equal("prune_nodes", msg.Event)
-	time.Sleep(time.Duration(3) * time.Microsecond)
+
+	// test for drop queue (only visible at test coverage)
+	conn.InsertNode(&runtime.Node{})
+	conn.InsertNode(&runtime.Node{})
+	conn.InsertNode(&runtime.Node{})
+	decoder.Decode(&msg)
 
 	// to reach in sendJSON removing of disconnection
 	conn.Close()

--- a/database/socket/database_test.go
+++ b/database/socket/database_test.go
@@ -1,0 +1,66 @@
+package socket
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/FreifunkBremen/yanic/runtime"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartup(t *testing.T) {
+	assert := assert.New(t)
+
+	config := make(map[string]interface{})
+
+	config["enable"] = false
+	conn, err := Connect(config)
+	assert.Nil(conn)
+
+	config["enable"] = true
+	config["type"] = ""
+	config["address"] = ""
+	conn, err = Connect(config)
+	assert.Error(err, "connection should not work")
+	assert.Nil(conn)
+
+	config["type"] = "unix"
+	config["address"] = "/tmp/yanic-database.socket"
+
+	conn, err = Connect(config)
+	assert.NoError(err, "connection should work")
+	assert.NotNil(conn)
+
+	conn.Close()
+}
+
+func TestClient(t *testing.T) {
+	assert := assert.New(t)
+
+	config := make(map[string]interface{})
+
+	config["enable"] = true
+	config["type"] = "unix"
+	config["address"] = "/tmp/yanic-database.socket"
+
+	conn, err := Connect(config)
+	assert.NoError(err, "connection should work")
+	assert.NotNil(conn)
+
+	client, err := net.Dial("unix", "/tmp/yanic-database.socket")
+	assert.NoError(err, "connection should work")
+	assert.NotNil(client)
+	time.Sleep(1)
+
+	conn.InsertNode(&runtime.Node{})
+	conn.InsertGlobals(&runtime.GlobalStats{}, time.Now())
+	conn.PruneNodes(time.Duration(3))
+
+	err = client.Close()
+	assert.NoError(err, "disconnect should work")
+	time.Sleep(1)
+	conn.InsertNode(&runtime.Node{})
+
+	conn.Close()
+}

--- a/database/socket/database_test.go
+++ b/database/socket/database_test.go
@@ -18,6 +18,7 @@ func TestStartup(t *testing.T) {
 	config["enable"] = false
 	conn, err := Connect(config)
 	assert.Nil(conn)
+	assert.NoError(err)
 
 	config["enable"] = true
 	config["type"] = ""

--- a/database/socket/database_test.go
+++ b/database/socket/database_test.go
@@ -26,8 +26,8 @@ func TestStartup(t *testing.T) {
 	assert.Error(err, "connection should not work")
 	assert.Nil(conn)
 
-	config["type"] = "unix"
-	config["address"] = "/tmp/yanic-database.socket"
+	config["type"] = "tcp6"
+	config["address"] = "[::]:1337"
 
 	conn, err = Connect(config)
 	assert.NoError(err, "connection should work")
@@ -42,14 +42,14 @@ func TestClient(t *testing.T) {
 	config := make(map[string]interface{})
 
 	config["enable"] = true
-	config["type"] = "unix"
-	config["address"] = "/tmp/yanic-database2.socket"
+	config["type"] = "tcp6"
+	config["address"] = "[::]:1337"
 
 	conn, err := Connect(config)
 	assert.NoError(err, "connection should work")
 	assert.NotNil(conn)
 
-	client, err := net.Dial("unix", "/tmp/yanic-database2.socket")
+	client, err := net.Dial("tcp6", "[::]:1337")
 	assert.NoError(err, "connection should work")
 	assert.NotNil(client)
 	time.Sleep(time.Duration(3) * time.Microsecond)

--- a/database/socket/database_test.go
+++ b/database/socket/database_test.go
@@ -62,22 +62,29 @@ func TestClient(t *testing.T) {
 	var msg Message
 
 	conn.InsertNode(&runtime.Node{})
-	decoder.Decode(&msg)
+	err = decoder.Decode(&msg)
+	assert.NoError(err)
 	assert.Equal("insert_node", msg.Event)
 
 	conn.InsertGlobals(&runtime.GlobalStats{}, time.Now())
-	decoder.Decode(&msg)
+	err = decoder.Decode(&msg)
+	assert.NoError(err)
 	assert.Equal("insert_globals", msg.Event)
 
+	conn.InsertLink(&runtime.Link{}, time.Now())
+	err = decoder.Decode(&msg)
+	assert.NoError(err)
+	assert.Equal("insert_link", msg.Event)
+
 	conn.PruneNodes(time.Hour * 24 * 7)
-	decoder.Decode(&msg)
+	err = decoder.Decode(&msg)
+	assert.NoError(err)
 	assert.Equal("prune_nodes", msg.Event)
 
 	// test for drop queue (only visible at test coverage)
 	conn.InsertNode(&runtime.Node{})
 	conn.InsertNode(&runtime.Node{})
 	conn.InsertNode(&runtime.Node{})
-	decoder.Decode(&msg)
 
 	// to reach in sendJSON removing of disconnection
 	conn.Close()

--- a/database/socket/database_test.go
+++ b/database/socket/database_test.go
@@ -26,8 +26,8 @@ func TestStartup(t *testing.T) {
 	assert.Error(err, "connection should not work")
 	assert.Nil(conn)
 
-	config["type"] = "tcp6"
-	config["address"] = "[::]:1337"
+	config["type"] = "tcp4"
+	config["address"] = "127.0.0.1:10337"
 
 	conn, err = Connect(config)
 	assert.NoError(err, "connection should work")
@@ -42,14 +42,14 @@ func TestClient(t *testing.T) {
 	config := make(map[string]interface{})
 
 	config["enable"] = true
-	config["type"] = "tcp6"
-	config["address"] = "[::]:1337"
+	config["type"] = "tcp4"
+	config["address"] = "127.0.0.1:10337"
 
 	conn, err := Connect(config)
 	assert.NoError(err, "connection should work")
 	assert.NotNil(conn)
 
-	client, err := net.Dial("tcp6", "[::]:1337")
+	client, err := net.Dial("tcp4", "127.0.0.1:10337")
 	assert.NoError(err, "connection should work")
 	assert.NotNil(client)
 	time.Sleep(time.Duration(3) * time.Microsecond)

--- a/database/socket/database_test.go
+++ b/database/socket/database_test.go
@@ -15,15 +15,9 @@ func TestStartup(t *testing.T) {
 
 	config := make(map[string]interface{})
 
-	config["enable"] = false
-	conn, err := Connect(config)
-	assert.Nil(conn)
-	assert.NoError(err)
-
-	config["enable"] = true
 	config["type"] = ""
 	config["address"] = ""
-	conn, err = Connect(config)
+	conn, err := Connect(config)
 	assert.Error(err, "connection should not work")
 	assert.Nil(conn)
 

--- a/database/socket/database_test.go
+++ b/database/socket/database_test.go
@@ -60,7 +60,7 @@ func TestClient(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal("insert_node", msg.Event)
 
-	conn.InsertGlobals(&runtime.GlobalStats{}, time.Now())
+	conn.InsertGlobals(&runtime.GlobalStats{}, time.Now(), "global")
 	err = decoder.Decode(&msg)
 	assert.NoError(err)
 	assert.Equal("insert_globals", msg.Event)

--- a/database/socket/database_test.go
+++ b/database/socket/database_test.go
@@ -2,6 +2,7 @@ package socket
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -52,39 +53,39 @@ func TestClient(t *testing.T) {
 	assert.NotNil(client)
 	time.Sleep(time.Duration(3) * time.Microsecond)
 
-	decoder := json.NewDecoder(client)
 	var msg Message
 
+	fmt.Println("[run] insert node")
 	conn.InsertNode(&runtime.Node{})
-	err = decoder.Decode(&msg)
+	err = json.NewDecoder(client).Decode(&msg)
+	fmt.Println("[result] insert node")
 	assert.NoError(err)
-	assert.Equal("insert_node", msg.Event)
+	assert.Equal(MessageEventInsertNode, msg.Event)
 
-	conn.InsertGlobals(&runtime.GlobalStats{}, time.Now(), "global")
-	err = decoder.Decode(&msg)
+	fmt.Println("[run] insert globals")
+	conn.InsertGlobals(&runtime.GlobalStats{}, time.Now(), runtime.GLOBAL_SITE)
+	err = json.NewDecoder(client).Decode(&msg)
+	fmt.Println("[result] insert globals")
 	assert.NoError(err)
-	assert.Equal("insert_globals", msg.Event)
+	assert.Equal(MessageEventInsertGlobals, msg.Event)
 
+	fmt.Println("[run] insert link")
 	conn.InsertLink(&runtime.Link{}, time.Now())
-	err = decoder.Decode(&msg)
+	err = json.NewDecoder(client).Decode(&msg)
+	fmt.Println("[result] insert link")
 	assert.NoError(err)
-	assert.Equal("insert_link", msg.Event)
+	assert.Equal(MessageEventInsertLink, msg.Event)
 
+	fmt.Println("[run] prune nodes")
 	conn.PruneNodes(time.Hour * 24 * 7)
-	err = decoder.Decode(&msg)
+	err = json.NewDecoder(client).Decode(&msg)
+	fmt.Println("[result] prune nodes")
 	assert.NoError(err)
-	assert.Equal("prune_nodes", msg.Event)
+	assert.Equal(MessageEventPruneNodes, msg.Event)
 
-	// test for drop queue (only visible at test coverage)
-	conn.InsertNode(&runtime.Node{})
-	conn.InsertNode(&runtime.Node{})
-	conn.InsertNode(&runtime.Node{})
+	//TODO test for drop queue (only visible at test coverage)
 
 	// to reach in sendJSON removing of disconnection
 	conn.Close()
-
-	conn.InsertNode(&runtime.Node{})
-	err = decoder.Decode(&msg)
-	assert.Error(err)
 
 }

--- a/database/socket/internal.go
+++ b/database/socket/internal.go
@@ -4,12 +4,17 @@ import (
 	"encoding/json"
 	"log"
 	"net"
+	"strings"
 )
 
 func (conn *Connection) handleSocketConnection(ln net.Listener) {
 	for {
 		c, err := ln.Accept()
 		if err != nil {
+			if strings.Contains(err.Error(), "use of closed network connection") {
+				log.Println("[socket-database] connection already closed, no new client")
+				return
+			}
 			log.Println("[socket-database] error during connection of a client", err)
 			continue
 		}
@@ -19,17 +24,21 @@ func (conn *Connection) handleSocketConnection(ln net.Listener) {
 	}
 }
 
-func (conn *Connection) sendJSON(msg Message) {
-	conn.clientMux.Lock()
-	for addr, c := range conn.clients {
-		d := json.NewEncoder(c)
-
-		err := d.Encode(&msg)
-		if err != nil {
-			log.Println("[socket-database] client has not recieve event:", err)
-			c.Close()
-			delete(conn.clients, addr)
+func (conn *Connection) writer() {
+	for msg := range conn.buffer {
+		conn.clientMux.Lock()
+		for addr, c := range conn.clients {
+			err := json.NewEncoder(c).Encode(&msg)
+			if err != nil {
+				log.Println("[socket-database] client has not recieve event:", err)
+				c.Close()
+				delete(conn.clients, addr)
+			}
 		}
+		conn.clientMux.Unlock()
 	}
-	conn.clientMux.Unlock()
+}
+
+func (conn *Connection) sendJSON(msg *Message) {
+	conn.buffer <- msg
 }

--- a/database/socket/internal.go
+++ b/database/socket/internal.go
@@ -2,7 +2,6 @@ package socket
 
 import (
 	"encoding/json"
-	"log"
 	"net"
 )
 
@@ -15,7 +14,6 @@ func (config *Connection) handleSocketConnection(ln net.Listener) {
 	for {
 		c, err := ln.Accept()
 		if err != nil {
-			log.Println("[socket-database] error during connection of a client", err)
 			continue
 		}
 		config.clients[c.RemoteAddr()] = c
@@ -28,10 +26,7 @@ func (conn *Connection) sendJSON(msg EventMessage) {
 
 		err := d.Encode(&msg)
 		if err != nil {
-			err = c.Close()
-			if err != nil {
-				log.Println("[socket-database] connection could not close after error on sending event:", err)
-			}
+			c.Close()
 			delete(conn.clients, i)
 		}
 	}

--- a/database/socket/internal.go
+++ b/database/socket/internal.go
@@ -30,7 +30,7 @@ func (conn *Connection) writer() {
 		for addr, c := range conn.clients {
 			err := json.NewEncoder(c).Encode(&msg)
 			if err != nil {
-				log.Println("[socket-database] client has not recieve event:", err)
+				log.Println("[socket-database] client has not receive event:", err)
 				c.Close()
 				delete(conn.clients, addr)
 			}

--- a/database/socket/internal.go
+++ b/database/socket/internal.go
@@ -1,0 +1,38 @@
+package socket
+
+import (
+	"encoding/json"
+	"log"
+	"net"
+)
+
+type EventMessage struct {
+	Event string      `json:"event"`
+	Body  interface{} `json:"body,omitempty"`
+}
+
+func (config *Connection) handleSocketConnection(ln net.Listener) {
+	for {
+		c, err := ln.Accept()
+		if err != nil {
+			log.Println("[socket-database] error during connection of a client", err)
+			continue
+		}
+		config.clients[c.RemoteAddr()] = c
+	}
+}
+
+func (conn *Connection) sendJSON(msg EventMessage) {
+	for i, c := range conn.clients {
+		d := json.NewEncoder(c)
+
+		err := d.Encode(&msg)
+		if err != nil {
+			err = c.Close()
+			if err != nil {
+				log.Println("[socket-database] connection could not close after error on sending event:", err)
+			}
+			delete(conn.clients, i)
+		}
+	}
+}

--- a/database/socket/internal.go
+++ b/database/socket/internal.go
@@ -6,11 +6,6 @@ import (
 	"net"
 )
 
-type EventMessage struct {
-	Event string      `json:"event"`
-	Body  interface{} `json:"body,omitempty"`
-}
-
 func (conn *Connection) handleSocketConnection(ln net.Listener) {
 	for {
 		c, err := ln.Accept()
@@ -24,7 +19,7 @@ func (conn *Connection) handleSocketConnection(ln net.Listener) {
 	}
 }
 
-func (conn *Connection) sendJSON(msg EventMessage) {
+func (conn *Connection) sendJSON(msg Message) {
 	conn.clientMux.Lock()
 	for addr, c := range conn.clients {
 		d := json.NewEncoder(c)

--- a/database/socket/internal.go
+++ b/database/socket/internal.go
@@ -2,6 +2,7 @@ package socket
 
 import (
 	"encoding/json"
+	"log"
 	"net"
 )
 
@@ -14,6 +15,7 @@ func (config *Connection) handleSocketConnection(ln net.Listener) {
 	for {
 		c, err := ln.Accept()
 		if err != nil {
+			log.Println("[socket-database] error during connection of a client", err)
 			continue
 		}
 		config.clients[c.RemoteAddr()] = c
@@ -21,13 +23,14 @@ func (config *Connection) handleSocketConnection(ln net.Listener) {
 }
 
 func (conn *Connection) sendJSON(msg EventMessage) {
-	for i, c := range conn.clients {
+	for addr, c := range conn.clients {
 		d := json.NewEncoder(c)
 
 		err := d.Encode(&msg)
 		if err != nil {
+			log.Println("[socket-database] client has not recieve event:", err)
 			c.Close()
-			delete(conn.clients, i)
+			delete(conn.clients, addr)
 		}
 	}
 }

--- a/database/socket/message.go
+++ b/database/socket/message.go
@@ -3,6 +3,7 @@ package socket
 type Message struct {
 	Event string      `json:"event"`
 	Body  interface{} `json:"body,omitempty"`
+	Site  string      `json:"site"`
 }
 
 const (

--- a/database/socket/message.go
+++ b/database/socket/message.go
@@ -8,5 +8,6 @@ type Message struct {
 const (
 	MessageEventInsertNode    = "insert_node"
 	MessageEventInsertGlobals = "insert_globals"
+	MessageEventInsertLink    = "insert_link"
 	MessageEventPruneNodes    = "prune_nodes"
 )

--- a/database/socket/message.go
+++ b/database/socket/message.go
@@ -1,0 +1,12 @@
+package socket
+
+type Message struct {
+	Event string      `json:"event"`
+	Body  interface{} `json:"body,omitempty"`
+}
+
+const (
+	MessageEventInsertNode    = "insert_node"
+	MessageEventInsertGlobals = "insert_globals"
+	MessageEventPruneNodes    = "prune_nodes"
+)


### PR DESCRIPTION
The database-type `socket` should prevent services, which send unnecessary multicast respondd request.