### PR TITLE
[TASK] Add script to remove nodes by nodeid

### DIFF
--- a/contrib/yanic-remove-node
+++ b/contrib/yanic-remove-node
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+import json
+import argparse
+import sys
+
+
+def main(states, nodeid):
+    with open(states) as handle:
+        data = json.load(handle)
+
+    if nodeid in data['nodes']:
+        del data['nodes'][nodeid]
+        print("node {} removed".format(nodeid))
+    else:
+        print('node not in state file', file=sys.stderr)
+        sys.exit(1)
+
+    with open(states, 'w') as handle:
+        json.dump(data, handle)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-s', '--states', action='store', required=True,
+                        help='path to the states json file')
+    parser.add_argument('-n', '--nodeid', action='store', required=True,
+                        help='nodeid of the node to remove')
+
+    args = parser.parse_args()
+
+    main(args.states, args.nodeid)
+


### PR DESCRIPTION
I was fiddling with multidomain stuff and moved nodes between domains which caused duplicate nodeids in each domain, which meshviewer currently doesn't handle well.

Removing a node by hand is more than cumbersome, so a small script was needed. Not much, but sure worth sharing.

```
# yanic-remove-node -s /var/lib/yanic/state/ffda.json -n daff60000202
```

Prints a message if the node was
 - removed
 - not found