### PR TITLE
[TASK] influxdb: add site tag to node

### DIFF
--- a/database/influxdb/node.go
+++ b/database/influxdb/node.go
@@ -49,6 +49,9 @@ func (conn *Connection) InsertNode(node *runtime.Node) {
 
 	if nodeinfo := node.Nodeinfo; nodeinfo != nil {
 		tags.SetString("hostname", nodeinfo.Hostname)
+		if nodeinfo.System.SiteCode != "" {
+			tags.SetString("site", nodeinfo.System.SiteCode)
+		}
 		if owner := nodeinfo.Owner; owner != nil {
 			tags.SetString("owner", owner.Contact)
 		}

--- a/database/influxdb/node_test.go
+++ b/database/influxdb/node_test.go
@@ -51,6 +51,9 @@ func TestToInflux(t *testing.T) {
 			Owner: &data.Owner{
 				Contact: "nobody",
 			},
+			System: data.System{
+				SiteCode: "ffxx",
+			},
 			Wireless: &data.Wireless{
 				TxPower24: 3,
 				Channel24: 4,
@@ -128,6 +131,7 @@ func TestToInflux(t *testing.T) {
 	assert.EqualValues("deadbeef", tags["nodeid"])
 	assert.EqualValues("nobody", tags["owner"])
 	assert.EqualValues("testing", tags["autoupdater"])
+	assert.EqualValues("ffxx", tags["site"])
 	assert.EqualValues(0.5, fields["load"])
 	assert.EqualValues(0, fields["neighbours.lldp"])
 	assert.EqualValues(1, fields["neighbours.batadv"])


### PR DESCRIPTION
As Yanic now support multiple meshes in one instance it would be handy to have the _site_code_ as tag in the _node_ measurement. As I don't see a reason to also include the _site_name_ I shortened the tag name to _site_.