### PR TITLE
[TASK] add global statistics for individual sites

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -12,12 +12,13 @@ import (
 
 // importCmd represents the import command
 var importCmd = &cobra.Command{
-	Use:     "import <file.rrd>",
+	Use:     "import <file.rrd> <site>",
 	Short:   "Imports global statistics from the given RRD files, requires InfluxDB",
-	Example: "yanic import --config /etc/yanic.toml olddata.rrd",
-	Args:    cobra.ExactArgs(1),
+	Example: "yanic import --config /etc/yanic.toml olddata.rrd global",
+	Args:    cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		path := args[0]
+		site := args[1]
 		config := loadConfig()
 
 		connections, err := all.Connect(config.Database.Connection)
@@ -36,6 +37,7 @@ var importCmd = &cobra.Command{
 					Clients: uint32(ds.Clients),
 				},
 				ds.Time,
+				site,
 			)
 		}
 	},

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -26,7 +26,7 @@ var queryCmd = &cobra.Command{
 
 		nodes := runtime.NewNodes(&runtime.Config{})
 
-		collector := respond.NewCollector(nil, nodes, []string{iface}, 0)
+		collector := respond.NewCollector(nil, nodes, []string{}, []string{iface}, 0)
 		defer collector.Close()
 		collector.SendPacket(dstAddress)
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -58,7 +58,7 @@ var serveCmd = &cobra.Command{
 				time.Sleep(delay)
 			}
 
-			collector = respond.NewCollector(connections, nodes, config.Respondd.Interfaces, config.Respondd.Port)
+			collector = respond.NewCollector(connections, nodes, config.Respondd.Sites, config.Respondd.Interfaces, config.Respondd.Port)
 			collector.Start(config.Respondd.CollectInterval.Duration)
 			defer collector.Close()
 		}

--- a/config_example.toml
+++ b/config_example.toml
@@ -11,6 +11,8 @@ synchronize      = "1m"
 collect_interval = "1m"
 # interface that has an IP in your mesh network
 interfaces       = ["br-ffhb"]
+# list of sites to save stats for (empty for global only)
+sites            = []
 # define a port to listen
 # if not set or set to 0 the kernel will use a random free port at its own
 #port = 10001

--- a/database/all/internal.go
+++ b/database/all/internal.go
@@ -43,9 +43,9 @@ func (conn *Connection) InsertLink(link *runtime.Link, time time.Time) {
 	}
 }
 
-func (conn *Connection) InsertGlobals(stats *runtime.GlobalStats, time time.Time) {
+func (conn *Connection) InsertGlobals(stats *runtime.GlobalStats, time time.Time, site string) {
 	for _, item := range conn.list {
-		item.InsertGlobals(stats, time)
+		item.InsertGlobals(stats, time, site)
 	}
 }
 

--- a/database/database.go
+++ b/database/database.go
@@ -15,7 +15,7 @@ type Connection interface {
 	InsertLink(*runtime.Link, time.Time)
 
 	// InsertGlobals stores global statistics
-	InsertGlobals(*runtime.GlobalStats, time.Time)
+	InsertGlobals(*runtime.GlobalStats, time.Time, string)
 
 	// PruneNodes prunes historical per-node data
 	PruneNodes(deleteAfter time.Duration)

--- a/database/graphite/database.go
+++ b/database/graphite/database.go
@@ -9,10 +9,11 @@ import (
 )
 
 const (
-	MeasurementNode            = "node"     // Measurement for per-node statistics
-	MeasurementGlobal          = "global"   // Measurement for summarized global statistics
-	CounterMeasurementFirmware = "firmware" // Measurement for firmware statistics
-	CounterMeasurementModel    = "model"    // Measurement for model statistics
+	MeasurementNode               = "node"        // Measurement for per-node statistics
+	MeasurementGlobal             = "global"      // Measurement for summarized global statistics
+	CounterMeasurementFirmware    = "firmware"    // Measurement for firmware statistics
+	CounterMeasurementModel       = "model"       // Measurement for model statistics
+	CounterMeasurementAutoupdater = "autoupdater" // Measurement for autoupdater
 )
 
 type Connection struct {

--- a/database/graphite/global.go
+++ b/database/graphite/global.go
@@ -7,20 +7,30 @@ import (
 	"github.com/fgrosse/graphigo"
 )
 
-func (c *Connection) InsertGlobals(stats *runtime.GlobalStats, time time.Time) {
-	c.addPoint(GlobalStatsFields(stats))
-	c.addCounterMap(CounterMeasurementModel, stats.Models, time)
-	c.addCounterMap(CounterMeasurementFirmware, stats.Firmwares, time)
+func (c *Connection) InsertGlobals(stats *runtime.GlobalStats, time time.Time, site string) {
+	measurementGlobal := MeasurementGlobal
+	counterMeasurementModel := CounterMeasurementModel
+	counterMeasurementFirmware := CounterMeasurementFirmware
+
+	if site != runtime.GLOBAL_SITE {
+		measurementGlobal += "_" + site
+		counterMeasurementModel += "_" + site
+		counterMeasurementFirmware += "_" + site
+	}
+
+	c.addPoint(GlobalStatsFields(measurementGlobal, stats))
+	c.addCounterMap(counterMeasurementModel, stats.Models, time)
+	c.addCounterMap(counterMeasurementFirmware, stats.Firmwares, time)
 }
 
-func GlobalStatsFields(stats *runtime.GlobalStats) []graphigo.Metric {
+func GlobalStatsFields(name string, stats *runtime.GlobalStats) []graphigo.Metric {
 	return []graphigo.Metric{
-		{Name: MeasurementGlobal + ".nodes", Value: stats.Nodes},
-		{Name: MeasurementGlobal + ".gateways", Value: stats.Gateways},
-		{Name: MeasurementGlobal + ".clients.total", Value: stats.Clients},
-		{Name: MeasurementGlobal + ".clients.wifi", Value: stats.ClientsWifi},
-		{Name: MeasurementGlobal + ".clients.wifi24", Value: stats.ClientsWifi24},
-		{Name: MeasurementGlobal + ".clients.wifi5", Value: stats.ClientsWifi5},
+		{Name: name + ".nodes", Value: stats.Nodes},
+		{Name: name + ".gateways", Value: stats.Gateways},
+		{Name: name + ".clients.total", Value: stats.Clients},
+		{Name: name + ".clients.wifi", Value: stats.ClientsWifi},
+		{Name: name + ".clients.wifi24", Value: stats.ClientsWifi24},
+		{Name: name + ".clients.wifi5", Value: stats.ClientsWifi5},
 	}
 }
 

--- a/database/graphite/global.go
+++ b/database/graphite/global.go
@@ -11,16 +11,19 @@ func (c *Connection) InsertGlobals(stats *runtime.GlobalStats, time time.Time, s
 	measurementGlobal := MeasurementGlobal
 	counterMeasurementModel := CounterMeasurementModel
 	counterMeasurementFirmware := CounterMeasurementFirmware
+	counterMeasurementAutoupdater := CounterMeasurementAutoupdater
 
 	if site != runtime.GLOBAL_SITE {
 		measurementGlobal += "_" + site
 		counterMeasurementModel += "_" + site
 		counterMeasurementFirmware += "_" + site
+		counterMeasurementAutoupdater += "_" + site
 	}
 
 	c.addPoint(GlobalStatsFields(measurementGlobal, stats))
 	c.addCounterMap(counterMeasurementModel, stats.Models, time)
 	c.addCounterMap(counterMeasurementFirmware, stats.Firmwares, time)
+	c.addCounterMap(counterMeasurementAutoupdater, stats.Autoupdater, time)
 }
 
 func GlobalStatsFields(name string, stats *runtime.GlobalStats) []graphigo.Metric {

--- a/database/influxdb/global_test.go
+++ b/database/influxdb/global_test.go
@@ -9,14 +9,20 @@ import (
 	"github.com/FreifunkBremen/yanic/runtime"
 )
 
+const TEST_SITE = "ffxx"
+
 func TestGlobalStats(t *testing.T) {
-	stats := runtime.NewGlobalStats(createTestNodes())
+	stats := runtime.NewGlobalStats(createTestNodes(), []string{TEST_SITE})
 
 	assert := assert.New(t)
-	fields := GlobalStatsFields(stats)
 
-	// check fields
+	// check SITE_GLOBAL fields
+	fields := GlobalStatsFields(stats[runtime.GLOBAL_SITE])
 	assert.EqualValues(3, fields["nodes"])
+
+	// check TEST_SITE fields
+	fields = GlobalStatsFields(stats[TEST_SITE])
+	assert.EqualValues(2, fields["nodes"])
 }
 
 func createTestNodes() *runtime.Nodes {
@@ -33,6 +39,9 @@ func createTestNodes() *runtime.Nodes {
 			NodeID: "abcdef012345",
 			Hardware: data.Hardware{
 				Model: "TP-Link 841",
+			},
+			System: data.System{
+				SiteCode: TEST_SITE,
 			},
 		},
 	}
@@ -63,6 +72,9 @@ func createTestNodes() *runtime.Nodes {
 			VPN:    true,
 			Hardware: data.Hardware{
 				Model: "Xeon Multi-Core",
+			},
+			System: data.System{
+				SiteCode: TEST_SITE,
 			},
 		},
 	})

--- a/database/logging/file.go
+++ b/database/logging/file.go
@@ -56,8 +56,8 @@ func (conn *Connection) InsertLink(link *runtime.Link, time time.Time) {
 	conn.log("InsertLink: ", link)
 }
 
-func (conn *Connection) InsertGlobals(stats *runtime.GlobalStats, time time.Time) {
-	conn.log("InsertGlobals: [", time.String(), "] nodes: ", stats.Nodes, ", clients: ", stats.Clients, " models: ", len(stats.Models))
+func (conn *Connection) InsertGlobals(stats *runtime.GlobalStats, time time.Time, site string) {
+	conn.log("InsertGlobals: [", time.String(), "] site: ", site, ", nodes: ", stats.Nodes, ", clients: ", stats.Clients, " models: ", len(stats.Models))
 }
 
 func (conn *Connection) PruneNodes(deleteAfter time.Duration) {

--- a/respond/collector_test.go
+++ b/respond/collector_test.go
@@ -9,10 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const SITE_TEST = "ffxx"
+
 func TestCollector(t *testing.T) {
 	nodes := runtime.NewNodes(&runtime.Config{})
 
-	collector := NewCollector(nil, nodes, []string{}, 10001)
+	collector := NewCollector(nil, nodes, []string{SITE_TEST}, []string{}, 10001)
 	collector.Start(time.Millisecond)
 	time.Sleep(time.Millisecond * 10)
 	collector.Close()

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -12,6 +12,7 @@ type Config struct {
 		Enable          bool     `toml:"enable"`
 		Synchronize     Duration `toml:"synchronize"`
 		Interfaces      []string `toml:"interfaces"`
+		Sites           []string `toml:"sites"`
 		Port            int      `toml:"port"`
 		CollectInterval Duration `toml:"collect_interval"`
 	}

--- a/runtime/stats_test.go
+++ b/runtime/stats_test.go
@@ -8,26 +8,49 @@ import (
 	"github.com/FreifunkBremen/yanic/data"
 )
 
+const TEST_SITE = "ffxx"
+
 func TestGlobalStats(t *testing.T) {
-	stats := NewGlobalStats(createTestNodes())
+	stats := NewGlobalStats(createTestNodes(), []string{TEST_SITE})
 
 	assert := assert.New(t)
-	assert.EqualValues(1, stats.Gateways)
-	assert.EqualValues(3, stats.Nodes)
-	assert.EqualValues(25, stats.Clients)
+	assert.Len(stats, 2)
+
+	//check GLOBAL_SITE stats
+	assert.EqualValues(1, stats[GLOBAL_SITE].Gateways)
+	assert.EqualValues(3, stats[GLOBAL_SITE].Nodes)
+	assert.EqualValues(25, stats[GLOBAL_SITE].Clients)
 
 	// check models
-	assert.Len(stats.Models, 2)
-	assert.EqualValues(2, stats.Models["TP-Link 841"])
-	assert.EqualValues(1, stats.Models["Xeon Multi-Core"])
+	assert.Len(stats[GLOBAL_SITE].Models, 2)
+	assert.EqualValues(2, stats[GLOBAL_SITE].Models["TP-Link 841"])
+	assert.EqualValues(1, stats[GLOBAL_SITE].Models["Xeon Multi-Core"])
 
 	// check firmwares
-	assert.Len(stats.Firmwares, 1)
-	assert.EqualValues(1, stats.Firmwares["2016.1.6+entenhausen1"])
+	assert.Len(stats[GLOBAL_SITE].Firmwares, 1)
+	assert.EqualValues(1, stats[GLOBAL_SITE].Firmwares["2016.1.6+entenhausen1"])
 
 	// check autoupdater
-	assert.Len(stats.Autoupdater, 2)
-	assert.EqualValues(1, stats.Autoupdater["stable"])
+	assert.Len(stats[GLOBAL_SITE].Autoupdater, 2)
+	assert.EqualValues(1, stats[GLOBAL_SITE].Autoupdater["stable"])
+
+	// check TEST_SITE stats
+	assert.EqualValues(1, stats[TEST_SITE].Gateways)
+	assert.EqualValues(2, stats[TEST_SITE].Nodes)
+	assert.EqualValues(23, stats[TEST_SITE].Clients)
+
+	// check models
+	assert.Len(stats[TEST_SITE].Models, 2)
+	assert.EqualValues(1, stats[TEST_SITE].Models["TP-Link 841"])
+	assert.EqualValues(1, stats[TEST_SITE].Models["Xeon Multi-Core"])
+
+	// check firmwares
+	assert.Len(stats[TEST_SITE].Firmwares, 1)
+	assert.EqualValues(1, stats[TEST_SITE].Firmwares["2016.1.6+entenhausen1"])
+
+	// check autoupdater
+	assert.Len(stats[TEST_SITE].Autoupdater, 1)
+	assert.EqualValues(0, stats[TEST_SITE].Autoupdater["stable"])
 }
 
 func createTestNodes() *Nodes {
@@ -44,6 +67,9 @@ func createTestNodes() *Nodes {
 			NodeID: "abcdef012345",
 			Hardware: data.Hardware{
 				Model: "TP-Link 841",
+			},
+			System: data.System{
+				SiteCode: TEST_SITE,
 			},
 		},
 	}
@@ -81,6 +107,9 @@ func createTestNodes() *Nodes {
 			VPN:    true,
 			Hardware: data.Hardware{
 				Model: "Xeon Multi-Core",
+			},
+			System: data.System{
+				SiteCode: TEST_SITE,
 			},
 		},
 	})


### PR DESCRIPTION
As suggested in #98 this adds global statistics per configured site.

The sites for which individual statistics are created can be specified in the config and if the list is empty only the already existing global statistic is created.

```
[respondd]
sites = ["ffwi","ffmz"]
```

Site specific and global statistics are stored in different measurements. For _influxdb_ site specific data is stored inside `(global|firmware|model|autoupdater)_site` with tag `site=$sitecode`. As _graphite_ doesn't support tags (yet) one measurement `(global|firmware|model)_$sitecode` is created for each configured site.

Example output could be viewed under https://stats.freifunk-mwu.de/dashboard/db/freifunk-mwu-test