### PR TITLE
[TASK] add sites filter for outputs

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -52,6 +52,9 @@ offline_after = "10m"
 # List of nodeids of nodes that should be filtered out, so they won't appear in output
 #blacklist = ["00112233445566", "1337f0badead"]
 #
+# List of site_codes of nodes that should be included in the output
+#sites = ["ffhb"]
+#
 # set has_location to true if you want to include only nodes that have geo-coordinates set
 # (setting this to false has no sensible effect, unless you'd want to hide nodes that have coordinates)
 #has_location = true
@@ -71,6 +74,7 @@ path = "/var/www/html/meshviewer/data/meshviewer.json"
 
 #[nodes.output.meshviewer-ffrgb.filter]
 #no_owner = false
+#sites = ["ffhb"]
 #blacklist = ["00112233445566", "1337f0badead"]
 #has_location = true
 

--- a/docs/docs_configuration.md
+++ b/docs/docs_configuration.md
@@ -196,6 +196,7 @@ enable = true
 [nodes.output.example.filter]
 no_owner  = true
 blacklist = ["00112233445566", "1337f0badead"]
+sites = ["ffhb"]
 has_location = true
 [nodes.output.example.filter.in_area]
 latitude_min  = 34.30
@@ -222,6 +223,7 @@ For each output format there can be set different filters
 [nodes.output.example.filter]
 no_owner  = true
 blacklist = ["00112233445566", "1337f0badead"]
+sites = ["ffhb"]
 has_location = true
 [nodes.output.example.filter.in_area]
 latitude_min  = 34.30
@@ -248,6 +250,16 @@ List of nodeids of nodes that should be filtered out, so they won't appear in ou
 {% sample lang="toml" %}
 ```toml
 blacklist = ["00112233445566", "1337f0badead"]
+```
+{% endmethod %}
+
+
+### sites
+{% method %}
+List of site_codes of nodes that should be included in output
+{% sample lang="toml" %}
+```toml
+sites = ["ffhb"]
 ```
 {% endmethod %}
 

--- a/output/all/filter.go
+++ b/output/all/filter.go
@@ -18,6 +18,7 @@ func (f filterConfig) filtering(nodesOrigin *runtime.Nodes) *runtime.Nodes {
 		f.HasLocation(),
 		f.Blacklist(),
 		f.InArea(),
+		f.Sites(),
 		f.NoOwner(),
 	}
 

--- a/output/all/filter_sites.go
+++ b/output/all/filter_sites.go
@@ -1,0 +1,24 @@
+package all
+
+import "github.com/FreifunkBremen/yanic/runtime"
+
+func (f filterConfig) Sites() filterFunc {
+	v, ok := f["sites"]
+	if !ok {
+		return noFilter
+	}
+
+	list := make(map[string]interface{})
+	for _, site := range v.([]interface{}) {
+		list[site.(string)] = true
+	}
+
+	return func(node *runtime.Node) *runtime.Node {
+		if nodeinfo := node.Nodeinfo; nodeinfo != nil {
+			if _, ok := list[nodeinfo.System.SiteCode]; ok {
+				return node
+			}
+		}
+		return nil
+	}
+}

--- a/output/all/filter_sites_test.go
+++ b/output/all/filter_sites_test.go
@@ -1,0 +1,34 @@
+package all
+
+import (
+	"testing"
+
+	"github.com/FreifunkBremen/yanic/data"
+	"github.com/FreifunkBremen/yanic/runtime"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterSites(t *testing.T) {
+	assert := assert.New(t)
+	var config filterConfig
+
+	config = map[string]interface{}{}
+
+	filterSites := config.Sites()
+
+	n := filterSites(&runtime.Node{Nodeinfo: &data.NodeInfo{}})
+	assert.NotNil(n)
+
+	config["sites"] = []interface{}{"ffhb"}
+	filterSites = config.Sites()
+
+	n = filterSites(&runtime.Node{Nodeinfo: &data.NodeInfo{System: data.System{SiteCode: "ffxx"}}})
+	assert.Nil(n)
+
+	n = filterSites(&runtime.Node{Nodeinfo: &data.NodeInfo{System: data.System{SiteCode: "ffhb"}}})
+	assert.NotNil(n)
+
+	n = filterSites(&runtime.Node{})
+	assert.Nil(n)
+
+}


### PR DESCRIPTION
## Description
This add an option to filter the nodes in the outputs by their site_code.

## Motivation and Context
Currently you need to run one Yanic instance per mesh network if you want one map per site_code.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added also tests for my new code.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
