### PR TITLE
Support for multiple Batman advanced networks in meshviewer-ffrgb

### DIFF
--- a/output/meshviewer-ffrgb/struct.go
+++ b/output/meshviewer-ffrgb/struct.go
@@ -31,6 +31,7 @@ type Node struct {
 	GatewayIPv6    string        `json:"gateway6,omitempty"`
 	NodeID         string        `json:"node_id"`
 	MAC            string        `json:"mac"`
+	MACs           []string      `json:"macs"`
 	Addresses      []string      `json:"addresses"`
 	SiteCode       string        `json:"-"`
 	DomainCode     string        `json:"domain"`
@@ -84,6 +85,7 @@ func NewNode(nodes *runtime.Nodes, n *runtime.Node) *Node {
 	if nodeinfo := n.Nodeinfo; nodeinfo != nil {
 		node.NodeID = nodeinfo.NodeID
 		node.MAC = nodeinfo.Network.Mac
+		node.MACs = nodeinfo.Network.Mesh["bat0"].Interfaces.Other
 		node.SiteCode = nodeinfo.System.SiteCode
 		node.DomainCode = nodeinfo.System.DomainCode
 		node.Hostname = nodeinfo.Hostname


### PR DESCRIPTION
When you traceroute through the Batman network, you see kinds of MAC addresses.
So when we have a MAC address, we should be able to detect the corresponding device.

In Leipzig, we use distinct Batman networks and one router can be attached to several
of those networks.

That patch is not enough to support the case "serveral Batman networks" as we would
have need to join all devices. But this is one should make the discussion open,
how we can support routers that are connected to multiple networks.