### PR TITLE
add raw output support

### DIFF
--- a/docs/docs_configuration.md
+++ b/docs/docs_configuration.md
@@ -521,6 +521,21 @@ path     = "/var/www/html/meshviewer/data/nodelist.json"
 ```
 {% endmethod %}
 
+## [[nodes.output.raw]]
+{% method %}
+This output takes the respondd response as sent by the node and includes it in a JSON document.
+{% endmethod %}
+
+
+### path
+{% method %}
+The path, where to store raw.json
+{% sample lang="toml" %}
+```toml
+path     = "/var/www/html/meshviewer/data/raw.json"
+```
+{% endmethod %}
+
 
 
 ## [database]

--- a/output/all/main.go
+++ b/output/all/main.go
@@ -5,4 +5,5 @@ import (
 	_ "github.com/FreifunkBremen/yanic/output/meshviewer"
 	_ "github.com/FreifunkBremen/yanic/output/meshviewer-ffrgb"
 	_ "github.com/FreifunkBremen/yanic/output/nodelist"
+	_ "github.com/FreifunkBremen/yanic/output/raw"
 )

--- a/output/raw/output.go
+++ b/output/raw/output.go
@@ -1,0 +1,46 @@
+package nodelist
+
+import (
+	"errors"
+
+	"github.com/FreifunkBremen/yanic/output"
+	"github.com/FreifunkBremen/yanic/runtime"
+)
+
+type Output struct {
+	output.Output
+	path string
+}
+
+type Config map[string]interface{}
+
+func (c Config) Path() string {
+	if path, ok := c["path"]; ok {
+		return path.(string)
+	}
+	return ""
+}
+
+func init() {
+	output.RegisterAdapter("raw", Register)
+}
+
+func Register(configuration map[string]interface{}) (output.Output, error) {
+	var config Config
+	config = configuration
+
+	if path := config.Path(); path != "" {
+		return &Output{
+			path: path,
+		}, nil
+	}
+	return nil, errors.New("no path given")
+
+}
+
+func (o *Output) Save(nodes *runtime.Nodes) {
+	nodes.RLock()
+	defer nodes.RUnlock()
+
+	runtime.SaveJSON(transform(nodes), o.path)
+}

--- a/output/raw/raw.go
+++ b/output/raw/raw.go
@@ -1,0 +1,45 @@
+package nodelist
+
+import (
+	"github.com/FreifunkBremen/yanic/data"
+	"github.com/FreifunkBremen/yanic/lib/jsontime"
+	"github.com/FreifunkBremen/yanic/runtime"
+)
+
+// Node struct
+type RawNode struct {
+	Firstseen  jsontime.Time    `json:"firstseen"`
+	Lastseen   jsontime.Time    `json:"lastseen"`
+	Online     bool             `json:"online"`
+	Statistics *data.Statistics `json:"statistics"`
+	Nodeinfo   *data.Nodeinfo   `json:"nodeinfo"`
+	Neighbours *data.Neighbours `json:"neighbours"`
+}
+
+type NodeList struct {
+	Version   string        `json:"version"`
+	Timestamp jsontime.Time `json:"updated_at"` // Timestamp of the generation
+	List      []*RawNode    `json:"nodes"`
+}
+
+func transform(nodes *runtime.Nodes) *NodeList {
+	nodelist := &NodeList{
+		Version:   "1.0.0",
+		Timestamp: jsontime.Now(),
+	}
+
+	for _, nodeOrigin := range nodes.List {
+		if nodeOrigin != nil {
+			node := &RawNode{
+				Firstseen:  nodeOrigin.Firstseen,
+				Lastseen:   nodeOrigin.Lastseen,
+				Online:     nodeOrigin.Online,
+				Statistics: nodeOrigin.Statistics,
+				Nodeinfo:   nodeOrigin.Nodeinfo,
+				Neighbours: nodeOrigin.Neighbours,
+			}
+			nodelist.List = append(nodelist.List, node)
+		}
+	}
+	return nodelist
+}

--- a/output/raw/raw_test.go
+++ b/output/raw/raw_test.go
@@ -1,0 +1,67 @@
+package nodelist
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/FreifunkBremen/yanic/data"
+	"github.com/FreifunkBremen/yanic/runtime"
+)
+
+func TestTransform(t *testing.T) {
+	nodes := transform(createTestNodes())
+
+	assert := assert.New(t)
+	assert.Len(nodes.List, 3)
+}
+
+func createTestNodes() *runtime.Nodes {
+	nodes := runtime.NewNodes(&runtime.NodesConfig{})
+
+	nodeData := &runtime.Node{
+		Statistics: &data.Statistics{
+			Clients: data.Clients{
+				Total: 23,
+			},
+		},
+		Nodeinfo: &data.Nodeinfo{
+			NodeID: "abcdef012345",
+			Hardware: data.Hardware{
+				Model: "TP-Link 841",
+			},
+		},
+	}
+	nodeData.Nodeinfo.Software.Firmware.Release = "2016.1.6+entenhausen1"
+	nodes.AddNode(nodeData)
+
+	nodes.AddNode(&runtime.Node{
+		Statistics: &data.Statistics{
+			Clients: data.Clients{
+				Total: 2,
+			},
+		},
+		Nodeinfo: &data.Nodeinfo{
+			NodeID: "112233445566",
+			Hardware: data.Hardware{
+				Model: "TP-Link 841",
+			},
+			Location: &data.Location{
+				Latitude:  23,
+				Longitude: 2,
+			},
+		},
+	})
+
+	nodes.AddNode(&runtime.Node{
+		Nodeinfo: &data.Nodeinfo{
+			NodeID: "0xdeadbeef0x",
+			VPN:    true,
+			Hardware: data.Hardware{
+				Model: "Xeon Multi-Core",
+			},
+		},
+	})
+
+	return nodes
+}


### PR DESCRIPTION
## Description
Add a output format which just passes the raw data as received by
respondd, i.e. in sections "statistics", "nodeinfo" and "neighbours".

## Motivation and Context
We use data from respondd to segment our network. It is therefore important for us
to get all information.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have added also tests for my new code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
