### PR TITLE
[TASK] Add support for custom respondd fields

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,6 +46,10 @@
   version = "0.0.2"
 
 [[constraint]]
+  name = "github.com/tidwall/gjson"
+  version = "1.3.4"
+
+[[constraint]]
   name = "github.com/stretchr/testify"
   version = "1.2.1"
 

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -44,11 +44,12 @@ var queryCmd = &cobra.Command{
 			}
 			ifacesConfigs = append(ifacesConfigs, ifaceConfig)
 		}
+		var config respond.Config
+		config.Interfaces = ifacesConfigs
 
 		nodes := runtime.NewNodes(&runtime.NodesConfig{})
 
-		sitesDomains := make(map[string][]string)
-		collector := respond.NewCollector(nil, nodes, sitesDomains, ifacesConfigs)
+		collector := respond.NewCollector(nil, nodes, &config)
 		defer collector.Close()
 		collector.SendPacket(dstAddress)
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -55,7 +55,7 @@ var serveCmd = &cobra.Command{
 				time.Sleep(delay)
 			}
 
-			collector = respond.NewCollector(allDatabase.Conn, nodes, config.Respondd.SitesDomains(), config.Respondd.Interfaces)
+			collector = respond.NewCollector(allDatabase.Conn, nodes, &config.Respondd)
 			collector.Start(config.Respondd.CollectInterval.Duration)
 			defer collector.Close()
 		}

--- a/config_example.toml
+++ b/config_example.toml
@@ -10,6 +10,16 @@ synchronize      = "1m"
 # how often request per multicast
 collect_interval = "1m"
 
+# If you have custom respondd fields, you can ask Yanic to also collect these.
+# NOTE: This does not automatically include these fields in the output.
+#       The meshviewer-ffrgb output module will include them under "custom_fields",
+#       but other modules may simply ignore them.
+#[[respondd.custom_field]]
+#name = zip
+# You can use arbitrary GJSON expressions here, see https://github.com/tidwall/gjson
+# We expect this expression to return a string.
+#path = nodeinfo.location.zip
+
 # table of a site to save stats for (not exists for global only)
 #[respondd.sites.example]
 ## list of domains on this site to save stats for (empty for global only)

--- a/data/response.go
+++ b/data/response.go
@@ -2,7 +2,8 @@ package data
 
 // ResponseData struct
 type ResponseData struct {
-	Neighbours *Neighbours `json:"neighbours"`
-	Nodeinfo   *Nodeinfo   `json:"nodeinfo"`
-	Statistics *Statistics `json:"statistics"`
+	Neighbours   *Neighbours            `json:"neighbours"`
+	Nodeinfo     *Nodeinfo              `json:"nodeinfo"`
+	Statistics   *Statistics            `json:"statistics"`
+	CustomFields map[string]interface{} `json:"-"`
 }

--- a/docs/docs_configuration.md
+++ b/docs/docs_configuration.md
@@ -18,6 +18,12 @@ collect_interval = "1m"
 #[respondd.sites.example]
 #domains            = ["city"]
 
+#[[respondd.custom_field]]
+#name = zip
+# You can use arbitrary GJSON expressions here, see https://github.com/tidwall/gjson
+# We expect this expression to return a string.
+#path = nodeinfo.location.zip
+
 [[respondd.interfaces]]
 ifname             = "br-ffhb"
 #ip_address        = "fe80::..."
@@ -147,6 +153,24 @@ If not set or set to 0 the kernel will use a random free port at its own.
 port              = 10001
 ```
 {% endmethod %}
+
+### [[respondd.custom_fields]]
+{% method %}
+If you have custom respondd fields, you can ask Yanic to also collect these.
+
+NOTE: This does not automatically include these fields in the output.
+The meshviewer-ffrgb output module will include them under "custom_fields",
+but other modules may simply ignore them.
+
+{% sample lang="toml" %}
+```toml
+name = zip
+# You can use arbitrary GJSON expressions here, see https://github.com/tidwall/gjson
+# We expect this expression to return a string.
+path = nodeinfo.location.zip
+```
+{% endmethod %}
+
 
 
 ## [webserver]

--- a/output/filter/noowner/noowner.go
+++ b/output/filter/noowner/noowner.go
@@ -41,7 +41,8 @@ func (no *noowner) Apply(node *runtime.Node) *runtime.Node {
 				VPN:      nodeinfo.VPN,
 				Wireless: nodeinfo.Wireless,
 			},
-			Neighbours: node.Neighbours,
+			Neighbours:   node.Neighbours,
+			CustomFields: node.CustomFields,
 		}
 	}
 	return node

--- a/output/meshviewer-ffrgb/struct.go
+++ b/output/meshviewer-ffrgb/struct.go
@@ -14,33 +14,34 @@ type Meshviewer struct {
 }
 
 type Node struct {
-	Firstseen      jsontime.Time `json:"firstseen"`
-	Lastseen       jsontime.Time `json:"lastseen"`
-	IsOnline       bool          `json:"is_online"`
-	IsGateway      bool          `json:"is_gateway"`
-	Clients        uint32        `json:"clients"`
-	ClientsWifi24  uint32        `json:"clients_wifi24"`
-	ClientsWifi5   uint32        `json:"clients_wifi5"`
-	ClientsOthers  uint32        `json:"clients_other"`
-	RootFSUsage    float64       `json:"rootfs_usage"`
-	LoadAverage    float64       `json:"loadavg"`
-	MemoryUsage    *float64      `json:"memory_usage,omitempty"`
-	Uptime         jsontime.Time `json:"uptime,omitempty"`
-	GatewayNexthop string        `json:"gateway_nexthop,omitempty"`
-	GatewayIPv4    string        `json:"gateway,omitempty"`
-	GatewayIPv6    string        `json:"gateway6,omitempty"`
-	NodeID         string        `json:"node_id"`
-	MAC            string        `json:"mac"`
-	Addresses      []string      `json:"addresses"`
-	SiteCode       string        `json:"-"`
-	DomainCode     string        `json:"domain"`
-	Hostname       string        `json:"hostname"`
-	Owner          string        `json:"owner,omitempty"`
-	Location       *Location     `json:"location,omitempty"`
-	Firmware       Firmware      `json:"firmware,omitempty"`
-	Autoupdater    Autoupdater   `json:"autoupdater"`
-	Nproc          int           `json:"nproc"`
-	Model          string        `json:"model,omitempty"`
+	Firstseen      jsontime.Time          `json:"firstseen"`
+	Lastseen       jsontime.Time          `json:"lastseen"`
+	IsOnline       bool                   `json:"is_online"`
+	IsGateway      bool                   `json:"is_gateway"`
+	Clients        uint32                 `json:"clients"`
+	ClientsWifi24  uint32                 `json:"clients_wifi24"`
+	ClientsWifi5   uint32                 `json:"clients_wifi5"`
+	ClientsOthers  uint32                 `json:"clients_other"`
+	RootFSUsage    float64                `json:"rootfs_usage"`
+	LoadAverage    float64                `json:"loadavg"`
+	MemoryUsage    *float64               `json:"memory_usage,omitempty"`
+	Uptime         jsontime.Time          `json:"uptime,omitempty"`
+	GatewayNexthop string                 `json:"gateway_nexthop,omitempty"`
+	GatewayIPv4    string                 `json:"gateway,omitempty"`
+	GatewayIPv6    string                 `json:"gateway6,omitempty"`
+	NodeID         string                 `json:"node_id"`
+	MAC            string                 `json:"mac"`
+	Addresses      []string               `json:"addresses"`
+	SiteCode       string                 `json:"-"`
+	DomainCode     string                 `json:"domain"`
+	Hostname       string                 `json:"hostname"`
+	Owner          string                 `json:"owner,omitempty"`
+	Location       *Location              `json:"location,omitempty"`
+	Firmware       Firmware               `json:"firmware,omitempty"`
+	Autoupdater    Autoupdater            `json:"autoupdater"`
+	Nproc          int                    `json:"nproc"`
+	Model          string                 `json:"model,omitempty"`
+	CustomFields   map[string]interface{} `json:"custom_fields,omitempty"`
 }
 
 // Firmware out of software
@@ -152,6 +153,12 @@ func NewNode(nodes *runtime.Nodes, n *runtime.Node) *Node {
 		node.GatewayIPv6 = nodes.GetNodeIDbyAddress(statistic.GatewayIPv6)
 		if node.GatewayIPv6 == "" {
 			node.GatewayIPv6 = statistic.GatewayIPv6
+		}
+	}
+	if customFields := n.CustomFields; customFields != nil {
+		node.CustomFields = make(map[string]interface{})
+		for fieldName, fieldValue := range customFields {
+			node.CustomFields[fieldName] = fieldValue
 		}
 	}
 

--- a/output/meshviewer-ffrgb/struct_test.go
+++ b/output/meshviewer-ffrgb/struct_test.go
@@ -58,6 +58,10 @@ func TestRegister(t *testing.T) {
 				},
 			},
 		},
+		CustomFields: map[string]interface{}{
+			"custom_fields": "are_custom",
+			"custom_int":    3,
+		},
 	})
 	assert.NotNil(node)
 	assert.NotNil(node.Addresses)
@@ -66,4 +70,6 @@ func TestRegister(t *testing.T) {
 	assert.Equal(13.3, node.Location.Longitude)
 	assert.Equal(8.7, node.Location.Latitude)
 	assert.Equal(0.74, *node.MemoryUsage)
+	assert.Equal("are_custom", node.CustomFields["custom_fields"])
+	assert.Equal(3, node.CustomFields["custom_int"])
 }

--- a/output/raw/raw.go
+++ b/output/raw/raw.go
@@ -8,12 +8,13 @@ import (
 
 // Node struct
 type RawNode struct {
-	Firstseen  jsontime.Time    `json:"firstseen"`
-	Lastseen   jsontime.Time    `json:"lastseen"`
-	Online     bool             `json:"online"`
-	Statistics *data.Statistics `json:"statistics"`
-	Nodeinfo   *data.Nodeinfo   `json:"nodeinfo"`
-	Neighbours *data.Neighbours `json:"neighbours"`
+	Firstseen    jsontime.Time          `json:"firstseen"`
+	Lastseen     jsontime.Time          `json:"lastseen"`
+	Online       bool                   `json:"online"`
+	Statistics   *data.Statistics       `json:"statistics"`
+	Nodeinfo     *data.Nodeinfo         `json:"nodeinfo"`
+	Neighbours   *data.Neighbours       `json:"neighbours"`
+	CustomFields map[string]interface{} `json:"custom_fields"`
 }
 
 type NodeList struct {
@@ -31,12 +32,13 @@ func transform(nodes *runtime.Nodes) *NodeList {
 	for _, nodeOrigin := range nodes.List {
 		if nodeOrigin != nil {
 			node := &RawNode{
-				Firstseen:  nodeOrigin.Firstseen,
-				Lastseen:   nodeOrigin.Lastseen,
-				Online:     nodeOrigin.Online,
-				Statistics: nodeOrigin.Statistics,
-				Nodeinfo:   nodeOrigin.Nodeinfo,
-				Neighbours: nodeOrigin.Neighbours,
+				Firstseen:    nodeOrigin.Firstseen,
+				Lastseen:     nodeOrigin.Lastseen,
+				Online:       nodeOrigin.Online,
+				Statistics:   nodeOrigin.Statistics,
+				Nodeinfo:     nodeOrigin.Nodeinfo,
+				Neighbours:   nodeOrigin.Neighbours,
+				CustomFields: nodeOrigin.CustomFields,
 			}
 			nodelist.List = append(nodelist.List, node)
 		}

--- a/respond/collector_test.go
+++ b/respond/collector_test.go
@@ -16,8 +16,15 @@ const (
 
 func TestCollector(t *testing.T) {
 	nodes := runtime.NewNodes(&runtime.NodesConfig{})
+	config := &Config{
+		Sites: map[string]SiteConfig{
+			SITE_TEST: {
+				Domains: []string{DOMAIN_TEST},
+			},
+		},
+	}
 
-	collector := NewCollector(nil, nodes, map[string][]string{SITE_TEST: {DOMAIN_TEST}}, []InterfaceConfig{})
+	collector := NewCollector(nil, nodes, config)
 	collector.Start(time.Millisecond)
 	time.Sleep(time.Millisecond * 10)
 	collector.Close()

--- a/respond/collector_test.go
+++ b/respond/collector_test.go
@@ -41,10 +41,65 @@ func TestParse(t *testing.T) {
 		Raw: compressed,
 	}
 
-	data, err := res.parse()
+	data, err := res.parse([]CustomFieldConfig{})
 
 	assert.NoError(err)
 	assert.NotNil(data)
 
 	assert.Equal("f81a67a5e9c1", data.Nodeinfo.NodeID)
+}
+
+func TestParseCustomFields(t *testing.T) {
+	assert := assert.New(t)
+
+	// read testdata
+	compressed, err := ioutil.ReadFile("testdata/nodeinfo.flated")
+	assert.Nil(err)
+
+	res := &Response{
+		Raw: compressed,
+	}
+
+	customFields := []CustomFieldConfig{
+		{
+			Name: "my_custom_field",
+			Path: "nodeinfo.hostname",
+		},
+	}
+
+	data, err := res.parse(customFields)
+
+	assert.NoError(err)
+	assert.NotNil(data)
+
+	assert.Equal("Trillian", data.CustomFields["my_custom_field"])
+	assert.Equal("Trillian", data.Nodeinfo.Hostname)
+}
+
+func TestParseCustomFieldNotExistant(t *testing.T) {
+	assert := assert.New(t)
+
+	// read testdata
+	compressed, err := ioutil.ReadFile("testdata/nodeinfo.flated")
+	assert.Nil(err)
+
+	res := &Response{
+		Raw: compressed,
+	}
+
+	customFields := []CustomFieldConfig{
+		{
+			Name: "some_other_field",
+			Path: "nodeinfo.some_field_which_doesnt_exist",
+		},
+	}
+
+	data, err := res.parse(customFields)
+
+	assert.NoError(err)
+	assert.NotNil(data)
+
+	_, ok := data.CustomFields["some_other_field"]
+	assert.Equal("Trillian", data.Nodeinfo.Hostname)
+	assert.False(ok)
 }

--- a/respond/config.go
+++ b/respond/config.go
@@ -8,6 +8,7 @@ type Config struct {
 	Interfaces      []InterfaceConfig     `toml:"interfaces"`
 	Sites           map[string]SiteConfig `toml:"sites"`
 	CollectInterval duration.Duration     `toml:"collect_interval"`
+	CustomFields    []CustomFieldConfig   `toml:"custom_field"`
 }
 
 func (c *Config) SitesDomains() (result map[string][]string) {
@@ -28,4 +29,9 @@ type InterfaceConfig struct {
 	SendNoRequest    bool   `toml:"send_no_request"`
 	MulticastAddress string `toml:"multicast_address"`
 	Port             int    `toml:"port"`
+}
+
+type CustomFieldConfig struct {
+	Name string `toml:"name"`
+	Path string `toml:"path"`
 }

--- a/runtime/node.go
+++ b/runtime/node.go
@@ -9,13 +9,14 @@ import (
 
 // Node struct
 type Node struct {
-	Address    *net.UDPAddr     `json:"-"` // the last known address
-	Firstseen  jsontime.Time    `json:"firstseen"`
-	Lastseen   jsontime.Time    `json:"lastseen"`
-	Online     bool             `json:"online"`
-	Statistics *data.Statistics `json:"statistics"`
-	Nodeinfo   *data.Nodeinfo   `json:"nodeinfo"`
-	Neighbours *data.Neighbours `json:"-"`
+	Address      *net.UDPAddr           `json:"-"` // the last known address
+	Firstseen    jsontime.Time          `json:"firstseen"`
+	Lastseen     jsontime.Time          `json:"lastseen"`
+	Online       bool                   `json:"online"`
+	Statistics   *data.Statistics       `json:"statistics"`
+	Nodeinfo     *data.Nodeinfo         `json:"nodeinfo"`
+	Neighbours   *data.Neighbours       `json:"-"`
+	CustomFields map[string]interface{} `json:"custom_fields"`
 }
 
 // Link represents a link between two nodes

--- a/runtime/nodes.go
+++ b/runtime/nodes.go
@@ -83,6 +83,7 @@ func (nodes *Nodes) Update(nodeID string, res *data.ResponseData) *Node {
 	node.Neighbours = res.Neighbours
 	node.Nodeinfo = res.Nodeinfo
 	node.Statistics = res.Statistics
+	node.CustomFields = res.CustomFields
 
 	return node
 }


### PR DESCRIPTION
## Description
This commit allows to define custom fields in the configuration file, which
will cause Yanic to also save the values of these custom fields in its internal
data structures. Output modules can then decide whether they want to include
these fields. For most cases, this should avoid the need for patches in Yanic.

## Motivation and Context
At the moment, if one has a custom respondd module which includes custom
fields, Yanic will simply ignore these fields. Communities which have custom
fields have to maintain patches on Yanic to have them available.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added also tests for my new code.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
