### PR TITLE
Add source.hostname/target.hostname to influx output

### DIFF
--- a/database/influxdb/link.go
+++ b/database/influxdb/link.go
@@ -14,6 +14,12 @@ func (conn *Connection) InsertLink(link *runtime.Link, t time.Time) {
 	tags.SetString("source.addr", link.SourceAddress)
 	tags.SetString("target.id", link.TargetID)
 	tags.SetString("target.addr", link.TargetAddress)
+	if link.SourceHostname != "" {
+		tags.SetString("source.hostname", link.SourceHostname)
+	}
+	if link.TargetHostname != "" {
+		tags.SetString("target.hostname", link.TargetHostname)
+	}
 
 	conn.addPoint(MeasurementLink, tags, models.Fields{"tq": link.TQ * 100}, t)
 }

--- a/runtime/node.go
+++ b/runtime/node.go
@@ -22,9 +22,11 @@ type Node struct {
 // Link represents a link between two nodes
 type Link struct {
 	SourceID      string
+	SourceHostname string
 	SourceAddress string
 	TargetID      string
 	TargetAddress string
+	TargetHostname string
 	TQ            float32
 }
 

--- a/runtime/nodes.go
+++ b/runtime/nodes.go
@@ -117,13 +117,24 @@ func (nodes *Nodes) NodeLinks(node *Node) (result []Link) {
 	for sourceMAC, batadv := range neighbours.Batadv {
 		for neighbourMAC, link := range batadv.Neighbours {
 			if neighbourID := nodes.ifaceToNodeID[neighbourMAC]; neighbourID != "" {
-				result = append(result, Link{
+				neighbour := nodes.List[neighbours.NodeID]
+
+				link := Link{
 					SourceID:      neighbours.NodeID,
 					SourceAddress: sourceMAC,
 					TargetID:      neighbourID,
 					TargetAddress: neighbourMAC,
 					TQ:            float32(link.Tq) / 255.0,
-				})
+				}
+
+				if neighbour.Nodeinfo != nil {
+					link.SourceHostname = neighbour.Nodeinfo.Hostname
+				}
+				if node.Nodeinfo != nil {
+					link.TargetHostname = node.Nodeinfo.Hostname
+				}
+
+				result = append(result, link)
 			}
 		}
 	}


### PR DESCRIPTION
## Description
This adds the additional tags source.hostname and target.hostname to the influx link measurements.

## Motivation and Context
Grafana is currently not able to resolve the target.id or source.id into a human readable hostname. Therefore reading the neighbour graphs is quite difficult for humans. This is resolved by adding the additional tags source.hostname and target.hostname as suggested here.

With this change, we can build a graph like this:
![Screenshot from 2021-02-27 18-33-39](https://user-images.githubusercontent.com/601153/109395537-2f5c4f00-792d-11eb-9597-6ae5bc01cf05.png)



<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

This is just a very first draft, which probably needs some more var != nil checks or so. It's intended as a basis for discussion.

My Questions:
- Would you accept this feature in general?
- What do I have to change in the code to get this accepted?
    - Especially:
        - Which of the variables used do I need to check if they are `nil`? Is `nodes.List[neighbours.NodeID]` always there? Is `nodes.List[neighbours.NodeID].Nodeinfo` always there? Is `nodes.List[neighbours.NodeID].Nodeinfo.Hostname` always there? Do I have to check all of them?
        - Should I reindent the whole `Link` block and inside `append()` in the struct?

If you would like pick to this up and finish it by yourself, then I am also fine with this.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!---
- [ ] My code follows the code style of this project.
- [ ] I have added also tests for my new code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
-->