### PR TITLE
[BUG] fix target.hostname of links

### DIFF
--- a/runtime/nodes.go
+++ b/runtime/nodes.go
@@ -117,7 +117,7 @@ func (nodes *Nodes) NodeLinks(node *Node) (result []Link) {
 	for sourceMAC, batadv := range neighbours.Batadv {
 		for neighbourMAC, link := range batadv.Neighbours {
 			if neighbourID := nodes.ifaceToNodeID[neighbourMAC]; neighbourID != "" {
-				neighbour := nodes.List[neighbours.NodeID]
+				neighbour := nodes.List[neighbourID]
 
 				link := Link{
 					SourceID:      neighbours.NodeID,
@@ -128,10 +128,10 @@ func (nodes *Nodes) NodeLinks(node *Node) (result []Link) {
 				}
 
 				if neighbour.Nodeinfo != nil {
-					link.SourceHostname = neighbour.Nodeinfo.Hostname
+					link.TargetHostname = neighbour.Nodeinfo.Hostname
 				}
 				if node.Nodeinfo != nil {
-					link.TargetHostname = node.Nodeinfo.Hostname
+					link.SourceHostname = node.Nodeinfo.Hostname
 				}
 
 				result = append(result, link)


### PR DESCRIPTION
Before this commit, the value of target.hostname was incorrect.
It was accidentially pointing to the hostname of the source of
the link. This means target.hostname was equal to source.hostname.

Fixes: #197
Fixes: 0325aad24e1cd762c8e7204fa016d4d007a4419d

<!--- Use a prefix like [TASK], [BUGFIX], [DOC] or [TEST] and provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have added also tests for my new code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
