### PR TITLE
[DOC] Fix "Communities using Yanic" info in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,7 @@ Global Flags:
 
 ## Communities using Yanic
 * **Freifunk Bremen** uses InfluxDB, [Grafana](https://grafana.bremen.freifunk.net), and [Meshviewer](https://map.bremen.freifunk.net) with a patch to show state-version of `nodes.json`.
-* **Freifunk Nord** uses [hopglass](https://github.com/hopglass/hopglass) (commit 587740a) as frontend:  https://mesh.freifunknord.de/
-* **Freifunk Kiel** uses [Meshviewer](https://github.com/ffrgb/meshviewer/) as frontend: https://map.freifunk.in-kiel.de/
+* **Freifunk Nord** uses [meshviewer](https://github.com/ffrgb/meshviewer) (commit 587740a) as frontend:  https://mesh.freifunknord.de/
 * **Freifunk Hannover** uses [Grafana](https://stats.ffh.zone), InfluxDB, and [Meshviewer](https://hannover.freifunk.net/karte/).
 * **Freifunk Rhein-Sieg e.V.** uses InfluxDB, [Grafana](https://grafana.freifunk-rhein-sieg.net/), [Meshviewer](https://map.freifunk-rhein-sieg.net/) - see [Github](https://github.com/Freifunk-Rhein-Sieg/Ansible-FFlo)
 


### PR DESCRIPTION
Previously it said FF Nord was using yanic+Hopglass and FF Kiel was using yanic+ffrgb/Meshviewer, but actually FF Nord is using ffrgb/meshviewer and FF Kiel is not using yanic at all as can be seen by the /raw.json and /metrics API endpoints.
