### PR TITLE
[BUGFIX] Set IPV6_MULTICAST_IF for correct interface selection

### DIFF
--- a/.circleci/check-testfiles
+++ b/.circleci/check-testfiles
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # checks if every desired package has test files
 
 import os
@@ -15,7 +15,7 @@ for root, dirs, files in os.walk("."):
     continue
 
   # source files but not test files?
-  if len(filter(source_re.match, files)) > 0 and len(filter(test_re.match, files)) == 0:
+  if len(list(filter(source_re.match, files))) > 0 and len(list(filter(test_re.match, files))) == 0:
     print("no test files for {}".format(root))
     missing = True
 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/tidwall/gjson v1.6.5
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
-	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
+	golang.org/x/sys v0.0.0-20211002104244-808efd93c36d // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/fgrosse/graphigo.v2 v2.0.0-20151220153422-55a0a92a7030 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20211002104244-808efd93c36d h1:SABT8Vei3iTiu+Gy8KOzpSNz+W1EQ5YBCRtiEETxF+0=
+golang.org/x/sys v0.0.0-20211002104244-808efd93c36d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=


### PR DESCRIPTION
<!--- Use a prefix like [TASK], [BUGFIX], [DOC] or [TEST] and provide a general summary of your changes in the Title above -->

## Description
Set IPV6_MULTICAST_IF on the collector's UDP socket, so the correct outgoing interface is chosen when a non-link-local bind address is configured.

## Motivation and Context
Closes #167

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added also tests for my new code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
