### PR TITLE
[DOC] Explain how to receive old and new gluon nodes

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -40,6 +40,8 @@ ip_address = "fd2f:5119:f2d::5"
 #send_no_request = false
 # multicast address to destination of respondd
 # (optional - without definition used default ff05::2:1001)
+# Very old gluon uses "ff02::2:1001" as multicast, newer use ff05::2:1001. If you have old and new
+# gluon nodes on the same network, create a separate "respondd.interfaces" section for each mutlicast address.
 #multicast_address = "ff02::2:1001"
 # define a port to listen
 # if not set or set to 0 the kernel will use a random free port at its own


### PR DESCRIPTION
<!--- Use a prefix like [TASK], [BUGFIX], [DOC] or [TEST] and provide a general summary of your changes in the Title above -->

## Description
Add a comment that it's possible to have a `respondd.interfaces` section for different multicast addresses to work with old and new gluon nodes on the same network.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On our freifunk network are some nodes that multicast to ff02, some that multicast to ff05 and some intermediate versions that multicast to both. I added a hint to the docs how to configure the map to support both.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- (no code changes)
- [x] I have updated the documentation accordingly.
