### PR TITLE
[BUGFIX] Set timeout for InfluxDB HTTP client

### DIFF
--- a/database/influxdb/database.go
+++ b/database/influxdb/database.go
@@ -70,6 +70,7 @@ func Connect(configuration map[string]interface{}) (database.Connection, error) 
 		Username:           config.Username(),
 		Password:           config.Password(),
 		InsecureSkipVerify: config.InsecureSkipVerify(),
+		Timeout:            batchTimeout,
 	})
 
 	if err != nil {


### PR DESCRIPTION
## Motivation and Context
Freifunk München experiences the problem that whenever the Influx database is down, yanic stalls completely and doesn't even write the meshviewer JSONs anymore. This leads to a completely red map and a little bit of elevated heart rate, despite the network still being up.

## Description
If InfluxDB is down, and the remote host doesn't respond to the connection attempt with Refused/Port Closed/whatever but just drops the packets, `conn.client.Write()` in the `addWorker` (and other places where InfluxDB is contacted) hangs infinitely. The default client config has no timeout (https://pkg.go.dev/github.com/influxdata/influxdb1-client/v2#HTTPConfig).
When `conn.points` fills up to `batchMaxSize`, `conn.addPoint()` and `conn.InsertPoint()` stop as well, which makes `coll.saveResponse()` stop as well, not even updating the meshviewer data anymore.

To fix this I've added a timeout to the Influx client. I've set it to `batchTimeout`, as I think it's reasonable to expect one database call to finish before the next one is about to start.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have added also tests for my new code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
