### PR TITLE
[BUGFIX] yanic-import-timestamp: allow importing from other yanic instance

### DIFF
--- a/contrib/yanic-import-timestamp
+++ b/contrib/yanic-import-timestamp
@@ -27,7 +27,7 @@ with open(yanic_db_path, encoding='UTF-8') as handle:
 
 total = 0
 updated = 0
-yanic_date_format = '%Y-%m-%dT%H:%M:%S+0000'
+yanic_date_format = '%Y-%m-%dT%H:%M:%S%z'
 v1_date_format = '%Y-%m-%dT%H:%M:%S.%f'  # 2017-05-31T18:30:19.759610
 v2_date_format = '%Y-%m-%dT%H:%M:%S.%fZ'  # 2015-08-22T16:05:02.000Z
 version = legacy_db['version']
@@ -39,7 +39,7 @@ if version == 1:
     legacy_date_format = v1_date_format    # ffmap-backend
 elif version == 2:
     legacy_date_format = v2_date_format    # hopglass
-    fallback_date_format = v1_date_format  # ffmap-backend
+    fallback_date_format = yanic_date_format  # other yanic
 else:
     print('unhandled nodes.json version number!', file=sys.stderr)
     sys.exit(1)


### PR DESCRIPTION
## Description
This fixes an issue when an import from other yanic is needed.

The datetime can have different timezones with yanic_date_format. The latest yanic format is now used as a fallback if the millisecond format from hopglass is not present.

## Motivation and Context
fixes #220 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have added also tests for my new code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
