### PR TITLE
chore(docs): add install instructions for dev install

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,6 +25,17 @@ As root:
 go install github.com/FreifunkBremen/yanic@latest
 ```
 
+or to install a different checkout for example for development run:
+
+```sh
+git clone https://github.com/FreifunkBremen/yanic
+cd yanic
+go install .
+```
+
+Now you can use the binary in `~/go/bin/yanic`.
+If you specified `export GOPATH=/opt/go` the binary is located at `/opt/go/bin/yanic`.
+
 #### Work with other databases
 If you like to use another database solution than influxdb, Pull Requests are
 welcome. Just fork this project and create another subpackage within the folder

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -25,6 +25,14 @@ As root:
 go install github.com/FreifunkBremen/yanic@latest
 ```
 
+or to install a different checkout for example for development run:
+
+```sh
+git clone https://github.com/FreifunkBremen/yanic
+cd yanic
+go install .
+```
+
 ### Install
 
 ```sh


### PR DESCRIPTION
<!--- Use a prefix like fix:, feat:, chore(docs): or chore(test): and provide a general summary of your changes in the Title above -->

## Description
This adds a sentence on how to install the dev version, as the package complains when installed from other repos like `go install github.com/maurerle/yanic@install_dev` (as FreifunkBremen is mentioned everywhere and the package name does not match then)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
  - [ ] using [conventional commits](https://www.conventionalcommits.org/) (we like auto [release semver](https://semver.org/))
- [ ] I have added also tests for my new code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
