### PR TITLE
feat(database/influxdb) add information if a node is a gateway to influxdb

### DIFF
--- a/database/influxdb/node.go
+++ b/database/influxdb/node.go
@@ -34,6 +34,7 @@ func (conn *Connection) InsertNode(node *runtime.Node) {
 
 	tags := models.Tags{}
 	tags.SetString("nodeid", stats.NodeID)
+	tags.SetString("is_gateway", strconv.FormatBool(node.IsGateway()))
 
 	fields := models.Fields{
 		"load":             stats.LoadAverage,
@@ -190,12 +191,6 @@ func (conn *Connection) InsertNode(node *runtime.Node) {
 
 			"leases.allocated": dhcp.LeasesAllocated,
 			"leases.pruned":    dhcp.LeasesPruned,
-		}
-
-		// Tags
-		tags.SetString("nodeid", stats.NodeID)
-		if nodeinfo := node.Nodeinfo; nodeinfo != nil {
-			tags.SetString("hostname", nodeinfo.Hostname)
 		}
 
 		conn.addPoint(MeasurementDHCP, tags, fields, time)


### PR DESCRIPTION
<!--- Use a prefix like fix:, feat:, chore(docs): or chore(test): and provide a general summary of your changes in the Title above -->

## Description
I think that the information if a node is a gateway should also be available in the influxdb:

is_gateway is more meaningful than "vpn"  - which is the variable where this comes from actually.

I think, that this is more useful as a tag to filter than as a field of the data.
I did not find a way to add a boolean tag in influxdb, so I am writing it as string. (ref: https://stackoverflow.com/a/56989192 )

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
  - [x] using [conventional commits](https://www.conventionalcommits.org/) (we like auto [release semver](https://semver.org/))
- [x] I have added also tests for my new code.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
