### PR TITLE
feat(data): handle gluon target information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ coverage.out
 
 /node_modules
 .DS_Store
+
+yanic
+yanic_*

--- a/config_example.toml
+++ b/config_example.toml
@@ -213,7 +213,7 @@ password = ""
 # Tagging of the data (optional)
 [database.connection.influxdb.tags]
 # Tags used by Yanic would override the tags from this config
-# nodeid, hostname, owner, model, firmware_base, firmware_release,frequency11g and frequency11a are tags which are already used
+# nodeid, hostname, owner, model, firmware_base, firmware_release, firmware_target, firmware_subtarget, firmware_image_name, frequency11g and frequency11a are tags which are already used
 #tagname1 = "tagvalue 1"
 # some useful e.g.:
 #system   = "productive"
@@ -255,7 +255,7 @@ global = "yanic-persistent"
 # Tagging of the data (optional)
 [database.connection.influxdb2.tags]
 # Tags used by Yanic would override the tags from this config
-# nodeid, hostname, owner, model, firmware_base, firmware_release,frequency11g and frequency11a are tags which are already used
+# nodeid, hostname, owner, model, firmware_base, firmware_release, firmware_target, firmware_subtarget, firmware_image_name, frequency11g and frequency11a are tags which are already used
 #tagname1 = "tagvalue 1"
 # some useful e.g.:
 #system   = "productive"

--- a/data/nodeinfo.go
+++ b/data/nodeinfo.go
@@ -75,8 +75,11 @@ type Software struct {
 		PublicKey string `json:"public_key,omitempty"`
 	} `json:"fastd,omitempty"`
 	Firmware *struct {
-		Base    string `json:"base,omitempty"`
-		Release string `json:"release,omitempty"`
+		Base      string `json:"base,omitempty"`
+		Release   string `json:"release,omitempty"`
+		Target    string `json:"target,omitempty"`
+		Subtarget string `json:"subtarget,omitempty"`
+		ImageName string `json:"image_name,omitempty"`
 	} `json:"firmware,omitempty"`
 	StatusPage *struct {
 		API int `json:"api"`

--- a/data/nodeinfo_test.go
+++ b/data/nodeinfo_test.go
@@ -34,6 +34,9 @@ func TestNodeinfo(t *testing.T) {
 
 	assert.Equal("gluon-v2016.1.2", obj.Software.Firmware.Base)
 	assert.Equal("2016.1.2+bremen1", obj.Software.Firmware.Release)
+	assert.Equal("mpc85xx", obj.Software.Firmware.Target)
+	assert.Equal("p1010", obj.Software.Firmware.Subtarget)
+	assert.Equal("tp-link-tl-wdr4900-v1", obj.Software.Firmware.ImageName)
 
 	assert.Equal("TP-Link TL-WDR4900 v1", obj.Hardware.Model)
 }

--- a/data/nodeinfo_test.go
+++ b/data/nodeinfo_test.go
@@ -24,3 +24,16 @@ func TestNodeinfoBatAddresses(t *testing.T) {
 	assert.NotNil(addr)
 	assert.Equal([]string{"aa:aa:aa:aa:aa", "aa:aa:aa:aa:ab"}, addr)
 }
+
+func TestNodeinfo(t *testing.T) {
+	assert := assert.New(t)
+	obj := &Nodeinfo{}
+	testfile("nodeinfo.json", obj)
+
+	assert.Equal("stable", obj.Software.Autoupdater.Branch)
+
+	assert.Equal("gluon-v2016.1.2", obj.Software.Firmware.Base)
+	assert.Equal("2016.1.2+bremen1", obj.Software.Firmware.Release)
+
+	assert.Equal("TP-Link TL-WDR4900 v1", obj.Hardware.Model)
+}

--- a/data/testdata/nodeinfo.json
+++ b/data/testdata/nodeinfo.json
@@ -14,7 +14,10 @@
     },
     "firmware": {
       "base": "gluon-v2016.1.2",
-      "release": "2016.1.2+bremen1"
+      "release": "2016.1.2+bremen1",
+      "target": "mpc85xx",
+      "subtarget": "p1010",
+      "image_name": "tp-link-tl-wdr4900-v1"
     },
     "status-page": {
       "api": 1

--- a/database/influxdb/global_test.go
+++ b/database/influxdb/global_test.go
@@ -135,8 +135,11 @@ func createTestNodes() *runtime.Nodes {
 		},
 	}
 	nodeData.Nodeinfo.Software.Firmware = &struct {
-		Base    string `json:"base,omitempty"`
-		Release string `json:"release,omitempty"`
+		Base      string `json:"base,omitempty"`
+		Release   string `json:"release,omitempty"`
+		Target    string `json:"target,omitempty"`
+		Subtarget string `json:"subtarget,omitempty"`
+		ImageName string `json:"image_name,omitempty"`
 	}{
 		Release: "2016.1.6+entenhausen1",
 	}

--- a/database/influxdb/node.go
+++ b/database/influxdb/node.go
@@ -84,6 +84,9 @@ func (conn *Connection) InsertNode(node *runtime.Node) {
 		if nodeinfo.Software.Firmware != nil {
 			tags.SetString("firmware_base", nodeinfo.Software.Firmware.Base)
 			tags.SetString("firmware_release", nodeinfo.Software.Firmware.Release)
+			tags.SetString("firmware_target", nodeinfo.Software.Firmware.Target)
+			tags.SetString("firmware_subtarget", nodeinfo.Software.Firmware.Subtarget)
+			tags.SetString("firmware_image_name", nodeinfo.Software.Firmware.ImageName)
 		}
 		if nodeinfo.Software.Autoupdater != nil && nodeinfo.Software.Autoupdater.Enabled {
 			tags.SetString("autoupdater", nodeinfo.Software.Autoupdater.Branch)

--- a/database/influxdb/node_test.go
+++ b/database/influxdb/node_test.go
@@ -118,10 +118,16 @@ func TestToInflux(t *testing.T) {
 					Enabled: false,
 				},
 				Firmware: &struct {
-					Base    string `json:"base,omitempty"`
-					Release string `json:"release,omitempty"`
+					Base      string `json:"base,omitempty"`
+					Release   string `json:"release,omitempty"`
+					Target    string `json:"target,omitempty"`
+					Subtarget string `json:"subtarget,omitempty"`
+					ImageName string `json:"image_name,omitempty"`
 				}{
 					Base: "gluon",
+					Target: "x86",
+					Subtarget: "64",
+					ImageName: "x86-64",
 				},
 			},
 		},

--- a/database/influxdb2/node.go
+++ b/database/influxdb2/node.go
@@ -74,6 +74,9 @@ func (conn *Connection) InsertNode(node *runtime.Node) {
 		if nodeinfo.Software.Firmware != nil {
 			p.AddTag("firmware_base", nodeinfo.Software.Firmware.Base)
 			p.AddTag("firmware_release", nodeinfo.Software.Firmware.Release)
+			p.AddTag("firmware_target", nodeinfo.Software.Firmware.Target)
+			p.AddTag("firmware_subtarget", nodeinfo.Software.Firmware.Subtarget)
+			p.AddTag("firmware_image_name", nodeinfo.Software.Firmware.ImageName)
 		}
 		if nodeinfo.Software.Autoupdater != nil && nodeinfo.Software.Autoupdater.Enabled {
 			p.AddTag("autoupdater", nodeinfo.Software.Autoupdater.Branch)

--- a/output/geojson/geojson_test.go
+++ b/output/geojson/geojson_test.go
@@ -86,8 +86,11 @@ func createTestNodes() *runtime.Nodes {
 		},
 	}
 	nodeData.Nodeinfo.Software.Firmware = &struct {
-		Base    string `json:"base,omitempty"`
-		Release string `json:"release,omitempty"`
+		Base      string `json:"base,omitempty"`
+		Release   string `json:"release,omitempty"`
+		Target    string `json:"target,omitempty"`
+		Subtarget string `json:"subtarget,omitempty"`
+		ImageName string `json:"image_name,omitempty"`
 	}{
 		Release: "2019.1~exp42",
 	}

--- a/output/meshviewer-ffrgb/struct.go
+++ b/output/meshviewer-ffrgb/struct.go
@@ -50,8 +50,11 @@ type Node struct {
 
 // Firmware out of software
 type Firmware struct {
-	Base    string `json:"base,omitempty"`
-	Release string `json:"release,omitempty"`
+	Base      string `json:"base,omitempty"`
+	Release   string `json:"release,omitempty"`
+	Target    string `json:"target,omitempty"`
+	Subtarget string `json:"subtarget,omitempty"`
+	ImageName string `json:"image_name,omitempty"`
 }
 
 // Autoupdater

--- a/output/meshviewer-ffrgb/struct_test.go
+++ b/output/meshviewer-ffrgb/struct_test.go
@@ -43,8 +43,11 @@ func TestRegister(t *testing.T) {
 					Branch  string `json:"branch,omitempty"`
 				}{},
 				Firmware: &struct {
-					Base    string `json:"base,omitempty"`
-					Release string `json:"release,omitempty"`
+					Base      string `json:"base,omitempty"`
+					Release   string `json:"release,omitempty"`
+					Target    string `json:"target,omitempty"`
+					Subtarget string `json:"subtarget,omitempty"`
+					ImageName string `json:"image_name,omitempty"`
 				}{},
 			},
 		},

--- a/output/meshviewer/nodes_test.go
+++ b/output/meshviewer/nodes_test.go
@@ -39,8 +39,11 @@ func createTestNodes() *runtime.Nodes {
 		},
 	}
 	nodeData.Nodeinfo.Software.Firmware = &struct {
-		Base    string `json:"base,omitempty"`
-		Release string `json:"release,omitempty"`
+		Base      string `json:"base,omitempty"`
+		Release   string `json:"release,omitempty"`
+		Target    string `json:"target,omitempty"`
+		Subtarget string `json:"subtarget,omitempty"`
+		ImageName string `json:"image_name,omitempty"`
 	}{
 		Release: "2016.1.6+entenhausen1",
 	}

--- a/output/nodelist/nodelist_test.go
+++ b/output/nodelist/nodelist_test.go
@@ -33,8 +33,11 @@ func createTestNodes() *runtime.Nodes {
 		},
 	}
 	nodeData.Nodeinfo.Software.Firmware = &struct {
-		Base    string `json:"base,omitempty"`
-		Release string `json:"release,omitempty"`
+		Base      string `json:"base,omitempty"`
+		Release   string `json:"release,omitempty"`
+		Target    string `json:"target,omitempty"`
+		Subtarget string `json:"subtarget,omitempty"`
+		ImageName string `json:"image_name,omitempty"`
 	}{
 		Release: "2016.1.6+entenhausen1",
 	}

--- a/output/raw-jsonl/raw_jsonl_test.go
+++ b/output/raw-jsonl/raw_jsonl_test.go
@@ -82,8 +82,11 @@ func createTestNodes() *runtime.Nodes {
 		},
 	}
 	nodeData.Nodeinfo.Software.Firmware = &struct {
-		Base    string `json:"base,omitempty"`
-		Release string `json:"release,omitempty"`
+		Base      string `json:"base,omitempty"`
+		Release   string `json:"release,omitempty"`
+		Target    string `json:"target,omitempty"`
+		Subtarget string `json:"subtarget,omitempty"`
+		ImageName string `json:"image_name,omitempty"`
 	}{
 		Release: "2019.1~exp42",
 	}

--- a/output/raw/raw_test.go
+++ b/output/raw/raw_test.go
@@ -33,8 +33,11 @@ func createTestNodes() *runtime.Nodes {
 		},
 	}
 	nodeData.Nodeinfo.Software.Firmware = &struct {
-		Base    string `json:"base,omitempty"`
-		Release string `json:"release,omitempty"`
+		Base      string `json:"base,omitempty"`
+		Release   string `json:"release,omitempty"`
+		Target    string `json:"target,omitempty"`
+		Subtarget string `json:"subtarget,omitempty"`
+		ImageName string `json:"image_name,omitempty"`
 	}{
 		Release: "2016.1.6+entenhausen1",
 	}

--- a/runtime/stats_test.go
+++ b/runtime/stats_test.go
@@ -95,8 +95,11 @@ func createTestNodes() *Nodes {
 		},
 	}
 	nodeData.Nodeinfo.Software.Firmware = &struct {
-		Base    string `json:"base,omitempty"`
-		Release string `json:"release,omitempty"`
+		Base      string `json:"base,omitempty"`
+		Release   string `json:"release,omitempty"`
+		Target    string `json:"target,omitempty"`
+		Subtarget string `json:"subtarget,omitempty"`
+		ImageName string `json:"image_name,omitempty"`
 	}{
 		Release: "2016.1.6+entenhausen1",
 	}


### PR DESCRIPTION
<!--- Use a prefix like fix:, feat:, chore(docs): or chore(test): and provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

This adds support for the recently introduced OpenWrt Target Information in Gluon: https://github.com/freifunk-gluon/gluon/pull/3496

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Mainly beeing able to tell which Subtarget an x86 system is part of (64, generic, geode or legacy).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
  - [x] using [conventional commits](https://www.conventionalcommits.org/) (we like auto [release semver](https://semver.org/))
- [x] I have added also tests for my new code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
