### PR TITLE
feat(cmd/config): enable use of enviroment variables in config file

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -207,7 +207,8 @@ enable   = false
 address  = "http://localhost:8086"
 database = "ffhb"
 username = ""
-password = ""
+# you can use an environment variable like this, but you can also just put the password in here:
+password = "${YANIC_INFLUX_PASSWORD}"
 #insecure_skip_verify = true
 
 # Tagging of the data (optional)


### PR DESCRIPTION
## Description
This replaces all occurrences of variables in the `${VARNAME}` format with the respective enviroment variable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is quite useful to seperate secrets like passwords and sharable config.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
  - [x] using [conventional commits](https://www.conventionalcommits.org/) (we like auto [release semver](https://semver.org/))
- [x] I have added also tests for my new code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
